### PR TITLE
fix number of arguments in build_filtergraph call

### DIFF
--- a/ffplayout.py
+++ b/ffplayout.py
@@ -1320,7 +1320,7 @@ class GetSourceFromFolder:
                     filtergraph = build_filtergraph(
                         float(self.probe.format['duration']), 0.0,
                         float(self.probe.format['duration']), False, False,
-                        False, False, self.probe)
+                        False, self.probe)
 
                     yield ['-i', clip] + filtergraph
 
@@ -1330,7 +1330,7 @@ class GetSourceFromFolder:
                     filtergraph = build_filtergraph(
                         float(self.probe.format['duration']), 0.0,
                         float(self.probe.format['duration']), False, False,
-                        False, False, self.probe)
+                        False, self.probe)
 
                     yield [
                         '-i', self._media.store[self.index]


### PR DESCRIPTION
Hello.

Function build_filtergraph has 7 arguments, but in two places in code it receives 8, so error is raised and script doesn't work properly. I think this happens only when ffplayout plays from storage, not playlist.

I didn't had much time to look into internals, but looks like removing one False in each call fixes that problem and doesn't break anything.
Actually, author of #37 asked me to debug the problem and now he says that this commit also fixes that issue too.