### PR TITLE
fix embed frontend optional

### DIFF
--- a/ffplayout-api/src/main.rs
+++ b/ffplayout-api/src/main.rs
@@ -29,6 +29,9 @@ use api::{auth, routes::*};
 use db::{db_pool, models::LoginUser};
 use utils::{args_parse::Args, control::ProcessControl, db_path, init_config, run_args};
 
+#[cfg(any(debug_assertions, not(feature = "embed_frontend")))]
+use utils::public_path;
+
 use ffplayout_lib::utils::{init_logging, PlayoutConfig};
 
 #[cfg(not(debug_assertions))]
@@ -178,11 +181,11 @@ async fn main() -> std::io::Result<()> {
                     web_app.service(ResourceFiles::new("/", generated).resolve_not_found_to_root());
             }
 
-            #[cfg(debug_assertions)]
+            #[cfg(any(debug_assertions, not(feature = "embed_frontend")))]
             {
                 // in debug mode get frontend from path
                 web_app = web_app.service(
-                    Files::new("/", "./ffplayout-frontend/.output/public/")
+                    Files::new("/", public_path())
                         .index_file("index.html"),
                 );
             }

--- a/ffplayout-api/src/utils/mod.rs
+++ b/ffplayout-api/src/utils/mod.rs
@@ -169,6 +169,14 @@ pub fn public_path() -> PathBuf {
         return path;
     }
 
+    #[cfg(debug_assertions)]
+    {
+        let path = PathBuf::from("./ffplayout-frontend/.output/public/");
+        if path.is_dir() {
+            return path;
+        }
+    }
+
     PathBuf::from("./public/")
 }
 


### PR DESCRIPTION
Fixing the frontend loading issue by properly specifying the 'Root Directory' and index file. Disabling the 'embed_frontend' option in the 'ffplayout-api/Cargo.toml' build configuration prevented the frontend page from loading.