### PR TITLE
store DB_PATH in static

### DIFF
--- a/engine/src/db/mod.rs
+++ b/engine/src/db/mod.rs
@@ -1,15 +1,67 @@
 use std::{
+    borrow::Cow,
     io::{stdin, stdout, Write},
-    sync::OnceLock,
+    path::Path,
+    sync::{LazyLock, OnceLock},
 };
 
+use faccess::PathExt;
+use log::*;
 use sqlx::{migrate::MigrateDatabase, Pool, Sqlite, SqlitePool};
 
 pub mod handles;
 pub mod models;
 
-use crate::utils::DB_PATH;
+use crate::ARGS;
 use models::GlobalSettings;
+
+pub static DB_PATH: LazyLock<Result<Cow<'static, Path>, sqlx::Error>> = LazyLock::new(|| {
+    const DEFAULT_DIR: &str = "/usr/share/ffplayout/db/";
+    const DEFAULT_PATH: &str = "/usr/share/ffplayout/db/ffplayout.db";
+    const ASSET_DIR: &str = "./assets";
+    const ASSET_PATH: &str = "./assets/ffplayout.db";
+    const DB_NAME: &str = "ffplayout.db";
+
+    let path = if let Some(path) = ARGS.db.as_deref() {
+        let mut path = Cow::Borrowed(path);
+        if !path.is_absolute() {
+            path = std::env::current_dir()?.join(path).into();
+        }
+        if path.is_dir() {
+            path = path.join(DB_NAME).into();
+        }
+        path
+    } else {
+        let sys_path = Path::new(DEFAULT_DIR);
+        let asset_path = Path::new(ASSET_DIR);
+
+        if !sys_path.writable() {
+            error!("Path {} not writable!", sys_path.display());
+        }
+
+        if sys_path.is_dir() && sys_path.writable() {
+            Path::new(DEFAULT_PATH).into()
+        } else if asset_path.is_dir() {
+            Path::new(ASSET_PATH).into()
+        } else {
+            Path::new(DB_NAME).into()
+        }
+    };
+
+    if path.is_file() {
+        path.access(faccess::AccessMode::WRITE)?;
+    } else if let Some(p) = path.parent() {
+        p.access(faccess::AccessMode::WRITE)?;
+    } else {
+        return Err(
+            std::io::Error::new(std::io::ErrorKind::NotFound, "Database path not found").into(),
+        );
+    }
+
+    info!("Database path: {}", path.display());
+
+    Ok(path)
+});
 
 pub static GLOBAL_SETTINGS: OnceLock<GlobalSettings> = OnceLock::new();
 pub async fn db_pool() -> Result<Pool<Sqlite>, sqlx::Error> {

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -56,7 +56,7 @@ async fn main() -> std::io::Result<()> {
 
     let pool = db_pool()
         .await
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+        .map_err(io::Error::other)?;
 
     if let Err(c) = run_args(&pool).await {
         exit(c);

--- a/engine/src/utils/args_parse.rs
+++ b/engine/src/utils/args_parse.rs
@@ -25,7 +25,7 @@ use crate::utils::{
 use crate::ARGS;
 
 #[cfg(target_family = "unix")]
-use crate::utils::db_path;
+use crate::utils::DB_PATH;
 
 #[derive(Parser, Debug, Default, Clone)]
 #[clap(version,
@@ -567,7 +567,7 @@ pub async fn run_args(pool: &Pool<Sqlite>) -> Result<(), i32> {
 
 #[cfg(target_family = "unix")]
 async fn update_permissions() {
-    let db_path = Path::new(db_path().unwrap());
+    let db_path = DB_PATH.as_ref().unwrap();
     let uid = nix::unistd::Uid::current();
     let parent_owner = db_path.parent().unwrap().metadata().unwrap().uid();
     let user = nix::unistd::User::from_uid(parent_owner.into())

--- a/engine/src/utils/args_parse.rs
+++ b/engine/src/utils/args_parse.rs
@@ -24,9 +24,6 @@ use crate::utils::{
 };
 use crate::ARGS;
 
-#[cfg(target_family = "unix")]
-use crate::utils::DB_PATH;
-
 #[derive(Parser, Debug, Default, Clone)]
 #[clap(version,
     about = "ffplayout - 24/7 broadcasting solution",
@@ -567,6 +564,8 @@ pub async fn run_args(pool: &Pool<Sqlite>) -> Result<(), i32> {
 
 #[cfg(target_family = "unix")]
 async fn update_permissions() {
+    use crate::db::DB_PATH;
+
     let db_path = DB_PATH.as_ref().unwrap();
     let uid = nix::unistd::Uid::current();
     let parent_owner = db_path.parent().unwrap().metadata().unwrap().uid();

--- a/engine/src/utils/mod.rs
+++ b/engine/src/utils/mod.rs
@@ -1,16 +1,13 @@
 use std::{
-    borrow::Cow,
     env, fmt,
     net::TcpListener,
     path::{Path, PathBuf},
-    sync::LazyLock,
 };
 
 #[cfg(target_family = "unix")]
 use std::os::unix::fs::MetadataExt;
 
 use chrono::{format::ParseErrorKind, prelude::*};
-use faccess::PathExt;
 use log::*;
 use path_clean::PathClean;
 use rand::Rng;
@@ -160,54 +157,6 @@ impl fmt::Display for TextFilter {
         write!(f, "{s}")
     }
 }
-
-pub static DB_PATH: LazyLock<Result<Cow<'static, Path>, sqlx::Error>> = LazyLock::new(|| {
-    const DEFAULT_DIR: &str = "/usr/share/ffplayout/db/";
-    const DEFAULT_PATH: &str = "/usr/share/ffplayout/db/ffplayout.db";
-    const ASSET_DIR: &str = "./assets";
-    const ASSET_PATH: &str = "./assets/ffplayout.db";
-    const DB_NAME: &str = "ffplayout.db";
-
-    let path = if let Some(path) = ARGS.db.as_deref() {
-        let mut path = Cow::Borrowed(path);
-        if !path.is_absolute() {
-            path = env::current_dir()?.join(path).into();
-        }
-        if path.is_dir() {
-            path = path.join(DB_NAME).into();
-        }
-        path
-    } else {
-        let sys_path = Path::new(DEFAULT_DIR);
-        let asset_path = Path::new(ASSET_DIR);
-
-        if !sys_path.writable() {
-            error!("Path {} not writable!", sys_path.display());
-        }
-
-        if sys_path.is_dir() && sys_path.writable() {
-            Path::new(DEFAULT_PATH).into()
-        } else if asset_path.is_dir() {
-            Path::new(ASSET_PATH).into()
-        } else {
-            Path::new(DB_NAME).into()
-        }
-    };
-
-    if path.is_file() {
-        path.access(faccess::AccessMode::WRITE)?;
-    } else if let Some(p) = path.parent() {
-        p.access(faccess::AccessMode::WRITE)?;
-    } else {
-        return Err(
-            std::io::Error::new(std::io::ErrorKind::NotFound, "Database path not found").into(),
-        );
-    }
-
-    info!("Database path: {}", path.display());
-
-    Ok(path)
-});
 
 pub fn public_path() -> PathBuf {
     let config = GLOBAL_SETTINGS.get().unwrap();


### PR DESCRIPTION
Store the computed db_path in a `LazyLock`.
Use `Cow<'static, Path>` to prevent memory leaks of the previous `Box::leak`.
Fail when the passed path is invalid instead of silently ignoring it.

Note:
`sqlx::MigrateDatabase` takes `&str` as parameter, so the `Path` has to be converted when needed. Even taking `impl AsRef<str>` would make it nicer, but that's just how it is.

:warning: 
This is a breaking change for installations, which depend on the silently ignored invalid Path given via cli args.