### PR TITLE
Improve desktop window handling and overlay rendering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,73 +1,181 @@
 name: Release
+
 on:
   release:
     types: [released, prereleased]
 
+permissions:
+  contents: write
+
 jobs:
   build:
+    name: ${{ matrix.platform }}-${{ matrix.variant }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            platform: x86_64-unknown-linux-gnu
+            variant: server
+            features: embed_frontend
+          - os: ubuntu-latest
+            platform: x86_64-unknown-linux-gnu
+            variant: desktop
+            features: embed_frontend,desktop
+          - os: macos-13
+            platform: x86_64-apple-darwin
+            variant: server
+            features: embed_frontend
+          - os: macos-13
+            platform: x86_64-apple-darwin
+            variant: desktop
+            features: embed_frontend,desktop
+          - os: macos-14
+            platform: aarch64-apple-darwin
+            variant: server
+            features: embed_frontend
+          - os: macos-14
+            platform: aarch64-apple-darwin
+            variant: desktop
+            features: embed_frontend,desktop
+          - os: windows-latest
+            platform: x86_64-pc-windows-msvc
+            variant: server
+            features: embed_frontend
+          - os: windows-latest
+            platform: x86_64-pc-windows-msvc
+            variant: desktop
+            features: embed_frontend,desktop
     runs-on: ${{ matrix.os }}
+
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_BUILD_JOBS: 1
+      VCPKGRS_DYNAMIC: 1
 
     steps:
       - uses: actions/checkout@v6
+
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-      - name: Install frontend dependencies
-        run: npm ci
+          cache: npm
+
       - name: Set up Rust
         run: |
           rustup update stable
 
-      - name: Build on Windows
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          cargo build --release
-          cp ./target/release/ffplayout.exe .
-          tar -a -c --exclude=*.service -f "ffplayout-${{ github.ref_name }}_x86_64-pc-windows-msvc.zip" assets docker docs LICENSE README.md CHANGELOG.md ffplayout.exe
-          del ffplayout.exe
+      - name: Set macOS Rust flags
+        if: runner.os == 'macOS'
+        run: echo 'RUSTFLAGS=-Csplit-debuginfo=packed' >> $GITHUB_ENV
 
-      - name: Build on macOS
-        if: ${{ matrix.os == 'macOS-latest' }}
-        run: |
-          rustup target add x86_64-apple-darwin
-          rustup target add aarch64-apple-darwin
-          cargo build --release --target=x86_64-apple-darwin
-          cargo build --release --target=aarch64-apple-darwin
-          cp ./target/x86_64-apple-darwin/release/ffplayout .
-          zip -r "ffplayout-${{ github.ref_name }}_x86_64-apple-darwin.zip" assets docker docs LICENSE README.md CHANGELOG.md ffplayout -x *.db -x *.db-shm -x *.db-wal -x *.service
-          rm -f ffplayout
-          cp ./target/aarch64-apple-darwin/release/ffplayout .
-          zip -r "ffplayout-${{ github.ref_name }}_aarch64-apple-darwin.zip" assets docker docs LICENSE README.md CHANGELOG.md ffplayout -x *.db -x *.db-shm -x *.db-wal -x *.service
-          rm -f ffplayout
-
-      - name: Build on Linux
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Install build dependencies on Linux
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get -y install musl musl-dev musl-tools pandoc gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev-arm64-cross
-          rustup target add x86_64-unknown-linux-musl
-          rustup target add aarch64-unknown-linux-gnu
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository -y ppa:ubuntuhandbook1/ffmpeg7
+          sudo apt-get update
+          packages=(
+            ffmpeg
+            libavcodec-dev
+            libavdevice-dev
+            libavfilter-dev
+            libavformat-dev
+            libavutil-dev
+            libswresample-dev
+            libswscale-dev
+            pandoc
+            pkg-config
+            rpm
+          )
+          if [[ "${{ matrix.variant }}" == "desktop" ]]; then
+            packages+=(libsdl2-dev)
+          fi
+          sudo apt-get install -y "${packages[@]}"
+          ffmpeg -version
+          test "$(pkg-config --modversion libavformat | cut -d. -f1)" -ge 61
+
+      - name: Install build dependencies on macOS
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          packages=(ffmpeg pkg-config)
+          if [[ "${{ matrix.variant }}" == "desktop" ]]; then
+            packages+=(sdl2)
+          fi
+          brew install "${packages[@]}"
+
+      - name: Install build dependencies on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $packages = @("ffmpeg:x64-windows")
+          if ("${{ matrix.variant }}" -eq "desktop") {
+            $packages += "sdl2:x64-windows"
+          }
+          vcpkg install $packages
+          echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" >> $env:GITHUB_ENV
+          echo "VCPKGRS_DYNAMIC=1" >> $env:GITHUB_ENV
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build on Linux
+        if: runner.os == 'Linux'
+        run: |
           ./scripts/man_create.sh
-          cargo install cargo-deb
-          cargo install cargo-generate-rpm
-          cargo build --release --target=x86_64-unknown-linux-musl
-          cargo build --release --target=aarch64-unknown-linux-gnu
-          tar --transform 's/\.\/target\/.*\///g' -czvf "ffplayout-${{ github.ref_name }}_x86_64-unknown-linux-musl.tar.gz" --exclude='*.db' --exclude='*.db-shm' --exclude='*.db-wal' assets docker docs LICENSE README.md CHANGELOG.md ./target/x86_64-unknown-linux-musl/release/ffplayout
-          cargo deb --no-build --target=x86_64-unknown-linux-musl -p ffplayout --manifest-path=engine/app/Cargo.toml -o ffplayout_${{ github.ref_name }}-1_amd64.deb
-          cargo generate-rpm --target=x86_64-unknown-linux-musl -p ffplayout -o ffplayout-${{ github.ref_name }}-1.x86_64.rpm
-          sed -i "s/x86_64-unknown-linux-musl/aarch64-unknown-linux-gnu/g" docker/*Dockerfile
-          tar --transform 's/\.\/target\/.*\///g' -czvf "ffplayout-${{ github.ref_name }}_aarch64-unknown-linux-gnu.tar.gz" --exclude='*.db' --exclude='*.db-shm' --exclude='*.db-wal' assets docker docs LICENSE README.md CHANGELOG.md ./target/aarch64-unknown-linux-gnu/release/ffplayout
-          cargo deb --no-build --target=aarch64-unknown-linux-gnu --variant=arm64 -p ffplayout --manifest-path=engine/app/Cargo.toml -o ffplayout_${{ github.ref_name }}-1_arm64.deb
+          cargo build --release --no-default-features --features "${{ matrix.features }}"
+          mkdir -p dist
+          tar --transform 's#^target/release/##' \
+            -czf "dist/ffplayout-${{ github.ref_name }}_${{ matrix.variant }}_${{ matrix.platform }}.tar.gz" \
+            --exclude='*.db' \
+            --exclude='*.db-shm' \
+            --exclude='*.db-wal' \
+            assets docker docs migrations LICENSE README.md target/release/ffplayout
+          if [[ "${{ matrix.variant }}" == "server" ]]; then
+            cargo install cargo-deb --locked
+            cargo install cargo-generate-rpm --locked
+            cargo deb --no-build \
+              -p ffplayout \
+              --manifest-path backend/app/Cargo.toml \
+              -o "dist/ffplayout_${{ github.ref_name }}-1_amd64.deb"
+            cargo generate-rpm \
+              --manifest-path backend/app/Cargo.toml \
+              -o "dist/ffplayout-${{ github.ref_name }}-1.x86_64.rpm"
+          fi
 
+      - name: Build on macOS
+        if: runner.os == 'macOS'
+        run: |
+          cargo build --release --no-default-features --features "${{ matrix.features }}"
+          mkdir -p dist
+          cp target/release/ffplayout .
+          zip -r "dist/ffplayout-${{ github.ref_name }}_${{ matrix.variant }}_${{ matrix.platform }}.zip" \
+            assets docker docs migrations LICENSE README.md ffplayout \
+            -x '*.db' '*.db-shm' '*.db-wal' '*.service'
+          rm -f ffplayout
 
-      - name: Upload Release Assets
+      - name: Build on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          cargo build --release --no-default-features --features "${{ matrix.features }}"
+          New-Item -ItemType Directory -Force -Path dist, package, package\bin | Out-Null
+          Copy-Item target\release\ffplayout.exe package\bin\
+          Copy-Item assets package\assets -Recurse
+          Copy-Item docker package\docker -Recurse
+          Copy-Item docs package\docs -Recurse
+          Copy-Item migrations package\migrations -Recurse
+          Copy-Item LICENSE, README.md package\
+          Get-ChildItem package\assets -Include *.db,*.db-shm,*.db-wal,*.service -Recurse | Remove-Item -Force
+          Compress-Archive -Path package\* -DestinationPath "dist\ffplayout-${{ github.ref_name }}_${{ matrix.variant }}_${{ matrix.platform }}.zip"
+
+      - name: Upload release assets
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ffplayout*
-          tag: ${{ github.ref }}
+          file: dist/ffplayout*
+          tag: ${{ github.ref_name }}
           overwrite: true
           file_glob: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
             cargo install cargo-deb --locked
             cargo install cargo-generate-rpm --locked
             package_version="${GITHUB_REF_NAME#v}"
-            package_version="${package_version//-/~}"
+            package_version="$(printf '%s' "$package_version" | sed 's/-/~/g')"
             cargo_deb_args=(
               --no-build
               -p ffplayout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,27 @@ jobs:
             platform: x86_64-unknown-linux-gnu
             variant: server
             features: embed_frontend
+            deb_arch: amd64
+            rpm_arch: x86_64
           - os: ubuntu-latest
             platform: x86_64-unknown-linux-gnu
             variant: desktop
             features: embed_frontend,desktop
-          - os: macos-13
+          - os: ubuntu-24.04-arm
+            platform: aarch64-unknown-linux-gnu
+            variant: server
+            features: embed_frontend
+            deb_arch: arm64
+            rpm_arch: aarch64
+          - os: ubuntu-24.04-arm
+            platform: aarch64-unknown-linux-gnu
+            variant: desktop
+            features: embed_frontend,desktop
+          - os: macos-15-intel
             platform: x86_64-apple-darwin
             variant: server
             features: embed_frontend
-          - os: macos-13
+          - os: macos-15-intel
             platform: x86_64-apple-darwin
             variant: desktop
             features: embed_frontend,desktop
@@ -142,14 +154,17 @@ jobs:
           if [[ "${{ matrix.variant }}" == "server" ]]; then
             cargo install cargo-deb --locked
             cargo install cargo-generate-rpm --locked
-            cargo deb --no-build \
-              -p ffplayout \
-              --manifest-path backend/app/Cargo.toml \
-              -o "dist/ffplayout_${{ github.ref_name }}-1_amd64.deb"
-            (
-              cd backend/app
-              cargo generate-rpm -p ffplayout -o "../../dist/ffplayout-${{ github.ref_name }}-1.x86_64.rpm"
+            cargo_deb_args=(
+              --no-build
+              -p ffplayout
+              --manifest-path backend/app/Cargo.toml
+              -o "dist/ffplayout_${{ github.ref_name }}-1_${{ matrix.deb_arch }}.deb"
             )
+            if [[ "${{ matrix.deb_arch }}" == "arm64" ]]; then
+              cargo_deb_args+=(--variant arm64)
+            fi
+            cargo deb "${cargo_deb_args[@]}"
+            cargo generate-rpm -p backend/app -o "dist/ffplayout-${{ github.ref_name }}-1.${{ matrix.rpm_arch }}.rpm"
           fi
 
       - name: Build on macOS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,12 @@ jobs:
             packages+=(sdl2)
           fi
           brew install "${packages[@]}"
+          brew_prefix="$(brew --prefix)"
+          {
+            echo "PKG_CONFIG_PATH=${brew_prefix}/lib/pkgconfig:${brew_prefix}/opt/ffmpeg/lib/pkgconfig:${brew_prefix}/opt/sdl2/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+            echo "LIBRARY_PATH=${brew_prefix}/lib:${brew_prefix}/opt/ffmpeg/lib:${brew_prefix}/opt/sdl2/lib:${LIBRARY_PATH:-}"
+            echo "DYLD_FALLBACK_LIBRARY_PATH=${brew_prefix}/lib:${brew_prefix}/opt/ffmpeg/lib:${brew_prefix}/opt/sdl2/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
+          } >> "$GITHUB_ENV"
 
       - name: Install build dependencies on Windows
         if: runner.os == 'Windows'
@@ -140,9 +146,10 @@ jobs:
               -p ffplayout \
               --manifest-path backend/app/Cargo.toml \
               -o "dist/ffplayout_${{ github.ref_name }}-1_amd64.deb"
-            cargo generate-rpm \
-              --manifest-path backend/app/Cargo.toml \
-              -o "dist/ffplayout-${{ github.ref_name }}-1.x86_64.rpm"
+            (
+              cd backend/app
+              cargo generate-rpm -p ffplayout -o "../../dist/ffplayout-${{ github.ref_name }}-1.x86_64.rpm"
+            )
           fi
 
       - name: Build on macOS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,17 +154,24 @@ jobs:
           if [[ "${{ matrix.variant }}" == "server" ]]; then
             cargo install cargo-deb --locked
             cargo install cargo-generate-rpm --locked
+            package_version="${GITHUB_REF_NAME#v}"
+            package_version="${package_version//-/~}"
             cargo_deb_args=(
               --no-build
               -p ffplayout
               --manifest-path backend/app/Cargo.toml
+              --deb-version "${package_version}-1"
               -o "dist/ffplayout_${{ github.ref_name }}-1_${{ matrix.deb_arch }}.deb"
             )
             if [[ "${{ matrix.deb_arch }}" == "arm64" ]]; then
               cargo_deb_args+=(--variant arm64)
             fi
             cargo deb "${cargo_deb_args[@]}"
-            cargo generate-rpm -p backend/app -o "dist/ffplayout-${{ github.ref_name }}-1.${{ matrix.rpm_arch }}.rpm"
+            cargo generate-rpm \
+              -p backend/app \
+              --set-metadata "version = \"${package_version}\"" \
+              --set-metadata "release = \"1\"" \
+              -o "dist/ffplayout-${{ github.ref_name }}-1.${{ matrix.rpm_arch }}.rpm"
           fi
 
       - name: Build on macOS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "ff-engine"
-version = "2.0.0-beta2"
+version = "2.0.0-beta3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "ffplayout"
-version = "2.0.0-beta2"
+version = "2.0.0-beta3"
 dependencies = [
  "argon2",
  "async-walkdir",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "2.0.0-beta2"
+version = "2.0.0-beta3"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,9 +391,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -1987,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd854a95a4ac672fed8c054136039fd32c22cf039ff09ead7280afe920486483"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
  "bitflags 2.13.0",
  "inotify-sys",
@@ -1998,9 +1998,9 @@ dependencies = [
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea94e891b3606826e9c998be69ddca42247dad8ad50b1649a5cb7e1c9ae06fd"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
@@ -2057,9 +2057,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -2071,9 +2071,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2306,9 +2306,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -2541,11 +2541,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -5016,18 +5015,18 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 description = "24/7 playout based on rust and ffmpeg"
 readme = "README.md"
-version = "2.0.0-beta2"
+version = "2.0.0-beta3"
 license = "GPL-3.0"
 repository = "https://github.com/ffplayout/ffplayout"
 authors = ["Jonathan Baecker <jonbae77@gmail.com>"]

--- a/backend/app/Cargo.toml
+++ b/backend/app/Cargo.toml
@@ -180,7 +180,6 @@ assets = [
 [package.metadata.generate-rpm]
 name = "ffplayout"
 license = "GPL-3.0"
-requires = ["ffmpeg"]
 assets = [
     { source = "../../target/release/ffplayout", dest = "/usr/bin/ffplayout", mode = "755" },
     { source = "../../assets/ffplayout.service", dest = "/lib/systemd/system/ffplayout.service", mode = "644" },

--- a/backend/app/Cargo.toml
+++ b/backend/app/Cargo.toml
@@ -94,8 +94,8 @@ name = "ffplayout"
 priority = "optional"
 section = "net"
 license-file = ["../../LICENSE", "0"]
-depends = "ffmpeg"
-suggests = ""
+depends = ""
+suggests = ["ffmpeg", "libsdl2-2.0-0"]
 copyright = "Copyright (c) 2024, Jonathan Baecker. All rights reserved."
 assets = [
     [
@@ -182,7 +182,7 @@ name = "ffplayout"
 license = "GPL-3.0"
 requires = ["ffmpeg"]
 assets = [
-    { source = "../../target/x86_64-unknown-linux-musl/release/ffplayout", dest = "/usr/bin/ffplayout", mode = "755" },
+    { source = "../../target/release/ffplayout", dest = "/usr/bin/ffplayout", mode = "755" },
     { source = "../../assets/ffplayout.service", dest = "/lib/systemd/system/ffplayout.service", mode = "644" },
     { source = "../../README.md", dest = "/usr/share/doc/ffplayout/README", mode = "644" },
     { source = "../../assets/ffplayout.1.gz", dest = "/usr/share/man/man1/ffplayout.1.gz", mode = "644", doc = true },

--- a/backend/app/Cargo.toml
+++ b/backend/app/Cargo.toml
@@ -94,8 +94,8 @@ name = "ffplayout"
 priority = "optional"
 section = "net"
 license-file = ["../../LICENSE", "0"]
-depends = ""
-suggests = "ffmpeg"
+depends = "ffmpeg"
+suggests = ""
 copyright = "Copyright (c) 2024, Jonathan Baecker. All rights reserved."
 assets = [
     [
@@ -180,6 +180,7 @@ assets = [
 [package.metadata.generate-rpm]
 name = "ffplayout"
 license = "GPL-3.0"
+requires = ["ffmpeg"]
 assets = [
     { source = "../../target/x86_64-unknown-linux-musl/release/ffplayout", dest = "/usr/bin/ffplayout", mode = "755" },
     { source = "../../assets/ffplayout.service", dest = "/lib/systemd/system/ffplayout.service", mode = "644" },

--- a/backend/app/Cargo.toml
+++ b/backend/app/Cargo.toml
@@ -145,16 +145,6 @@ assets = [
         "644",
     ],
     [
-        "../../assets/DejaVuSans.ttf",
-        "/usr/share/ffplayout/",
-        "644",
-    ],
-    [
-        "../../assets/FONT_LICENSE.txt",
-        "/usr/share/ffplayout/",
-        "644",
-    ],
-    [
         "../../assets/logo.png",
         "/usr/share/ffplayout/",
         "644",

--- a/backend/app/src/api/routes/playout_config.rs
+++ b/backend/app/src/api/routes/playout_config.rs
@@ -112,6 +112,7 @@ pub async fn update_playout_config(
         is_hls.then_some(data.output.hls_playlist_name.as_str()),
         is_hls.then_some(i64::from(data.output.hls_segment_duration)),
         is_hls.then_some(i64::from(data.output.hls_list_size)),
+        data.output.desktop_fullscreen,
         i64::from(data.output.width),
         i64::from(data.output.height),
         data.output.fps,

--- a/backend/app/src/db/handles/output.rs
+++ b/backend/app/src/db/handles/output.rs
@@ -18,7 +18,7 @@ pub async fn insert_output(
     channel_id: i32,
     output: &Output,
 ) -> Result<i32, ProcessError> {
-    const QUERY: &str = "INSERT INTO outputs (channel_id, name, hls_variants, stream_url, hls_playlist_name, hls_segment_duration, hls_list_size, width, height, fps, video_preset, rate_control, video_quality, video_maxrate, audio_bitrate) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) RETURNING id";
+    const QUERY: &str = "INSERT INTO outputs (channel_id, name, hls_variants, stream_url, hls_playlist_name, hls_segment_duration, hls_list_size, desktop_fullscreen, width, height, fps, video_preset, rate_control, video_quality, video_maxrate, audio_bitrate) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) RETURNING id";
 
     let output_id = sqlx::query(QUERY)
         .bind(channel_id)
@@ -28,6 +28,7 @@ pub async fn insert_output(
         .bind(&output.hls_playlist_name)
         .bind(output.hls_segment_duration)
         .bind(output.hls_list_size)
+        .bind(output.desktop_fullscreen)
         .bind(output.width)
         .bind(output.height)
         .bind(output.fps)
@@ -53,6 +54,7 @@ pub async fn update_output(
     hls_playlist_name: Option<&str>,
     hls_segment_duration: Option<i64>,
     hls_list_size: Option<i64>,
+    desktop_fullscreen: bool,
     width: i64,
     height: i64,
     fps: f64,
@@ -62,7 +64,7 @@ pub async fn update_output(
     video_maxrate: Option<i64>,
     audio_bitrate: Option<i64>,
 ) -> Result<SqliteQueryResult, ProcessError> {
-    const QUERY: &str = "UPDATE outputs SET hls_variants = $3, stream_url = $4, hls_playlist_name = $5, hls_segment_duration = $6, hls_list_size = $7, width = $8, height = $9, fps = $10, video_preset = $11, rate_control = $12, video_quality = $13, video_maxrate = $14, audio_bitrate = $15 WHERE id = $1 AND channel_id = $2";
+    const QUERY: &str = "UPDATE outputs SET hls_variants = $3, stream_url = $4, hls_playlist_name = $5, hls_segment_duration = $6, hls_list_size = $7, desktop_fullscreen = $8, width = $9, height = $10, fps = $11, video_preset = $12, rate_control = $13, video_quality = $14, video_maxrate = $15, audio_bitrate = $16 WHERE id = $1 AND channel_id = $2";
 
     let result = sqlx::query(QUERY)
         .bind(id)
@@ -72,6 +74,7 @@ pub async fn update_output(
         .bind(hls_playlist_name)
         .bind(hls_segment_duration)
         .bind(hls_list_size)
+        .bind(desktop_fullscreen)
         .bind(width)
         .bind(height)
         .bind(fps)

--- a/backend/app/src/db/models.rs
+++ b/backend/app/src/db/models.rs
@@ -442,6 +442,9 @@ pub struct Output {
     pub hls_playlist_name: Option<String>,
     pub hls_segment_duration: Option<i64>,
     pub hls_list_size: Option<i64>,
+    #[sqlx(default)]
+    #[serde(default)]
+    pub desktop_fullscreen: bool,
     pub width: i64,
     pub height: i64,
     pub fps: f64,
@@ -473,6 +476,7 @@ impl Output {
             hls_playlist_name,
             hls_segment_duration,
             hls_list_size,
+            desktop_fullscreen: false,
             width: 1280,
             height: 720,
             fps: 25.0,

--- a/backend/app/src/file/local.rs
+++ b/backend/app/src/file/local.rs
@@ -411,14 +411,10 @@ impl LocalStorage {
         if root.is_dir() {
             let target = root.join("00-assets");
             let mut dummy_source = Path::new("/usr/share/ffplayout/dummy.vtt");
-            let mut font_source = Path::new("/usr/share/ffplayout/DejaVuSans.ttf");
             let mut logo_source = Path::new("/usr/share/ffplayout/logo.png");
 
             if !dummy_source.is_file() {
                 dummy_source = Path::new("./assets/dummy.vtt");
-            }
-            if !font_source.is_file() {
-                font_source = Path::new("./assets/DejaVuSans.ttf");
             }
             if !logo_source.is_file() {
                 logo_source = Path::new("./assets/logo.png");
@@ -426,12 +422,10 @@ impl LocalStorage {
 
             if !target.is_dir() {
                 let dummy_target = target.join("dummy.vtt");
-                let font_target = target.join("DejaVuSans.ttf");
                 let logo_target = target.join("logo.png");
 
                 fs::create_dir_all(&target).await?;
                 fs::copy(&dummy_source, &dummy_target).await?;
-                fs::copy(&font_source, &font_target).await?;
                 fs::copy(&logo_source, &logo_target).await?;
 
                 #[cfg(target_family = "unix")]
@@ -449,13 +443,6 @@ impl LocalStorage {
                                 if dummy_target.is_file() {
                                     nix::unistd::chown(
                                         &dummy_target,
-                                        Some(user.uid),
-                                        Some(user.gid),
-                                    )?;
-                                }
-                                if font_target.is_file() {
-                                    nix::unistd::chown(
-                                        &font_target,
                                         Some(user.uid),
                                         Some(user.gid),
                                     )?;

--- a/backend/app/src/player/output/playout.rs
+++ b/backend/app/src/player/output/playout.rs
@@ -389,6 +389,7 @@ fn engine_output_config(
         .with_logo(logo)
         .with_text(text)
         .with_text_overlay_state(text_overlay_state)
+        .with_desktop_fullscreen(config.output.desktop_fullscreen)
         .with_logging(ffmpeg_log_level, ingest_log_level)
         .with_ffmpeg_ignore_lines(config.logging.ignore_lines.clone())
         .with_channel_id(config.general.channel_id)

--- a/backend/app/src/utils/config.rs
+++ b/backend/app/src/utils/config.rs
@@ -495,6 +495,8 @@ pub struct Output {
     pub hls_segment_duration: u32,
     #[serde(default = "default_hls_list_size")]
     pub hls_list_size: u32,
+    #[serde(default)]
+    pub desktop_fullscreen: bool,
     pub width: u32,
     pub height: u32,
     pub fps: f64,
@@ -572,6 +574,7 @@ impl Output {
                 .hls_list_size
                 .and_then(|value| u32::try_from(value).ok())
                 .unwrap_or_else(default_hls_list_size),
+            desktop_fullscreen: output.desktop_fullscreen,
             width: u32::try_from(output.width).unwrap_or(1280),
             height: u32::try_from(output.height).unwrap_or(720),
             fps: output.fps,
@@ -954,6 +957,7 @@ mod output_tests {
             hls_playlist_name: "stream".to_string(),
             hls_segment_duration: 6,
             hls_list_size: 600,
+            desktop_fullscreen: false,
             width: 1280,
             height: 720,
             fps: 25.0,

--- a/backend/engine/src/compositor/logo.rs
+++ b/backend/engine/src/compositor/logo.rs
@@ -158,13 +158,24 @@ fn parse_logo_dimension(value: &str, input: u32, output: u32) -> Result<Option<u
     if value == "W" || value == "H" || value == "main_w" || value == "main_h" {
         return Ok(Some(output));
     }
+    if let Some(percent) = value.strip_suffix('%') {
+        let percent = percent
+            .trim()
+            .parse::<f64>()
+            .map_err(|_| anyhow!("unsupported logo scale expression {value:?}"))?;
+        if !percent.is_finite() || percent <= 0.0 {
+            return Err(anyhow!("unsupported logo scale expression {value:?}"));
+        }
+
+        return Ok(Some(((f64::from(output) * percent) / 100.0).round() as u32));
+    }
     value
         .parse::<u32>()
         .map(Some)
         .map_err(|_| anyhow!("unsupported logo scale expression {value:?}"))
 }
 
-fn logo_position(
+pub(crate) fn logo_position(
     position: &str,
     output_width: u32,
     output_height: u32,
@@ -214,4 +225,27 @@ fn eval_position_expr(expr: &str, main: u32, overlay: u32) -> Result<i64> {
 
 pub fn blend_logo(target: &mut frame::Video, logo: &LogoOverlay, opacity_factor: f64) {
     blend_overlay(target, logo.as_overlay(), opacity_factor);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::logo_dimensions;
+
+    #[test]
+    fn logo_scale_accepts_output_percentages() {
+        assert_eq!(
+            logo_dimensions(Some("12%:-1"), 400, 200, 1920, 1080).unwrap(),
+            (230, 114)
+        );
+        assert_eq!(
+            logo_dimensions(Some("-1:10%"), 400, 200, 1920, 1080).unwrap(),
+            (216, 108)
+        );
+    }
+
+    #[test]
+    fn logo_scale_rejects_invalid_percentages() {
+        assert!(logo_dimensions(Some("0%:-1"), 400, 200, 1920, 1080).is_err());
+        assert!(logo_dimensions(Some("nan%:-1"), 400, 200, 1920, 1080).is_err());
+    }
 }

--- a/backend/engine/src/compositor/text.rs
+++ b/backend/engine/src/compositor/text.rs
@@ -5,11 +5,12 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow};
-use cosmic_text::{
-    Align, Attrs, Buffer, Color, Family, FontSystem, Metrics, Shaping, SwashCache, Weight, Wrap,
-};
+use cosmic_text::{Attrs, Buffer, Color, Family, FontSystem, Metrics, Shaping, SwashCache, Weight};
 use ffmpeg_next::{frame, util::format::pixel::Pixel};
 use regex::Regex;
+
+#[cfg(feature = "desktop")]
+use cosmic_text::{Align, Wrap};
 
 use crate::{
     compositor::overlay::{OverlayFrame, blend_overlay},
@@ -55,12 +56,14 @@ pub(crate) fn available_font_families() -> Vec<String> {
         .collect()
 }
 
+#[cfg(feature = "desktop")]
 pub(crate) struct TextBitmap {
     pub pixels: Vec<u8>,
     pub width: u32,
     pub height: u32,
 }
 
+#[cfg(feature = "desktop")]
 pub(crate) fn render_plain_text_bitmap(
     text: &str,
     font_size: f32,
@@ -70,6 +73,7 @@ pub(crate) fn render_plain_text_bitmap(
     render_text_bitmap(text, font_size, font_weight, color, None, None, None)
 }
 
+#[cfg(feature = "desktop")]
 pub(crate) fn render_wrapped_text_bitmap(
     text: &str,
     font_size: f32,
@@ -88,6 +92,7 @@ pub(crate) fn render_wrapped_text_bitmap(
     )
 }
 
+#[cfg(feature = "desktop")]
 fn render_text_bitmap(
     text: &str,
     font_size: f32,

--- a/backend/engine/src/compositor/text.rs
+++ b/backend/engine/src/compositor/text.rs
@@ -5,7 +5,9 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow};
-use cosmic_text::{Attrs, Buffer, Color, Family, FontSystem, Metrics, Shaping, SwashCache, Weight};
+use cosmic_text::{
+    Align, Attrs, Buffer, Color, Family, FontSystem, Metrics, Shaping, SwashCache, Weight, Wrap,
+};
 use ffmpeg_next::{frame, util::format::pixel::Pixel};
 use regex::Regex;
 
@@ -51,6 +53,119 @@ pub(crate) fn available_font_families() -> Vec<String> {
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect()
+}
+
+pub(crate) struct TextBitmap {
+    pub pixels: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+}
+
+pub(crate) fn render_plain_text_bitmap(
+    text: &str,
+    font_size: f32,
+    font_weight: Weight,
+    color: RgbaColor,
+) -> Result<TextBitmap> {
+    render_text_bitmap(text, font_size, font_weight, color, None, None, None)
+}
+
+pub(crate) fn render_wrapped_text_bitmap(
+    text: &str,
+    font_size: f32,
+    font_weight: Weight,
+    color: RgbaColor,
+    max_width: u32,
+) -> Result<TextBitmap> {
+    render_text_bitmap(
+        text,
+        font_size,
+        font_weight,
+        color,
+        Some(max_width.max(2)),
+        Some(Wrap::WordOrGlyph),
+        Some(Align::Center),
+    )
+}
+
+fn render_text_bitmap(
+    text: &str,
+    font_size: f32,
+    font_weight: Weight,
+    color: RgbaColor,
+    max_width: Option<u32>,
+    wrap: Option<Wrap>,
+    align: Option<Align>,
+) -> Result<TextBitmap> {
+    if text.trim().is_empty() {
+        return Err(anyhow!("text bitmap input is empty"));
+    }
+
+    let estimated_width = (text.chars().count() as f32 * font_size * 0.75).ceil() as u32 + 8;
+    let width = max_width
+        .unwrap_or(estimated_width)
+        .min(estimated_width.max(2))
+        .max(2);
+    let line_height = font_size * 1.25;
+    let estimated_lines =
+        ((estimated_width as f32 / width as f32).ceil() as u32).max(text.lines().count() as u32);
+    let height = ((line_height * estimated_lines as f32).ceil() as u32 + 4).max(2);
+    let mut rgba = vec![0_u8; width as usize * height as usize * 4];
+    let mut renderer = renderer().lock().unwrap_or_else(PoisonError::into_inner);
+    let TextRenderer {
+        font_system,
+        swash_cache,
+    } = &mut *renderer;
+    let mut buffer = Buffer::new(font_system, Metrics::new(font_size, line_height));
+    buffer.set_size(Some(width as f32), Some(height as f32));
+    if let Some(wrap) = wrap {
+        buffer.set_wrap(wrap);
+    }
+    buffer.set_text(
+        text,
+        &Attrs::new().weight(font_weight),
+        Shaping::Advanced,
+        align,
+    );
+    buffer.shape_until_scroll(font_system, false);
+
+    let mut bounds = Bounds::default();
+    buffer.draw(
+        font_system,
+        swash_cache,
+        Color::rgba(color.r, color.g, color.b, color.a),
+        |x, y, pixel_width, pixel_height, color| {
+            let color = rgba_color(color);
+            let Some(dest) = PixelRect::new(x, y, pixel_width, pixel_height, width, height) else {
+                return;
+            };
+
+            bounds.include(dest.x, dest.y, dest.width, dest.height);
+            for py in 0..dest.height {
+                for px in 0..dest.width {
+                    let idx = ((dest.y + py) * width as usize + dest.x + px) * 4;
+                    alpha_composite(&mut rgba[idx..idx + 4], color);
+                }
+            }
+        },
+    );
+
+    let Some(bounds) = bounds.finish() else {
+        return Err(anyhow!("text bitmap produced no visible pixels"));
+    };
+    let mut cropped = vec![0_u8; bounds.width * bounds.height * 4];
+    for y in 0..bounds.height {
+        let src_start = ((bounds.y + y) * width as usize + bounds.x) * 4;
+        let src_end = src_start + bounds.width * 4;
+        let dst_start = y * bounds.width * 4;
+        cropped[dst_start..dst_start + bounds.width * 4].copy_from_slice(&rgba[src_start..src_end]);
+    }
+
+    Ok(TextBitmap {
+        pixels: cropped,
+        width: bounds.width as u32,
+        height: bounds.height as u32,
+    })
 }
 
 pub struct TextOverlay {

--- a/backend/engine/src/input/live.rs
+++ b/backend/engine/src/input/live.rs
@@ -24,6 +24,7 @@ use log::{error, info, warn};
 
 use crate::{
     PlaybackControl,
+    compositor::logo::LogoOverlay,
     output::FrameOutput,
     playout::{InputPlaybackOptions, LogoFadePlan, Timeline, play_opened_input},
     utils::{config::OutputConfig, logging},
@@ -591,6 +592,15 @@ impl<O: FrameOutput> FrameOutput for LiveOverrideOutput<'_, O> {
         self.output.encode_audio(&frame)?;
         self.remember_audio_frame_end(pts + samples);
         Ok(())
+    }
+
+    fn apply_logo_overlay(
+        &mut self,
+        frame: &mut frame::Video,
+        logo: &LogoOverlay,
+        opacity_factor: f64,
+    ) {
+        self.output.apply_logo_overlay(frame, logo, opacity_factor);
     }
 
     fn set_video_end(&mut self, video_end_pts: Option<i64>) -> Result<()> {

--- a/backend/engine/src/lib.rs
+++ b/backend/engine/src/lib.rs
@@ -427,7 +427,9 @@ impl Playout {
     pub fn open_desktop(config: OutputConfig, fallback_duration: f64) -> Result<Self> {
         Self::validate_fallback_duration(fallback_duration)?;
         init_ffmpeg(&config)?;
-        let output = Output::open_desktop(&config)?;
+        let sdl = output::init_desktop_sdl()?;
+        let config = output::desktop_config_for_primary_display(config, &sdl);
+        let output = Output::open_desktop(&config, sdl)?;
 
         Ok(Self::with_output(config, output, fallback_duration))
     }

--- a/backend/engine/src/lib.rs
+++ b/backend/engine/src/lib.rs
@@ -380,14 +380,19 @@ fn run_async_playout_worker(mut playout: Playout, commands: mpsc::Receiver<Async
                 logo_fade,
                 response,
             } => {
-                let _ = response.send(playout.play_timed_with_live(
+                let result = playout.play_timed_with_live(
                     &path,
                     seek_seconds,
                     duration_seconds,
                     subtitles_media_path.as_deref(),
                     logo_fade,
                     &mut live,
-                ));
+                );
+                let stopped = matches!(result, Ok(ClipResult::Stopped));
+                let _ = response.send(result);
+                if stopped {
+                    break;
+                }
             }
             AsyncCommand::StartRtmpLive {
                 url,

--- a/backend/engine/src/output/desktop.rs
+++ b/backend/engine/src/output/desktop.rs
@@ -1,8 +1,10 @@
 use std::{
     collections::VecDeque,
+    ffi::c_void,
     mem::size_of,
     sync::{
-        Arc, Mutex,
+        Arc, Mutex, OnceLock,
+        atomic::{AtomicBool, Ordering},
         mpsc::{Receiver, RecvTimeoutError, SyncSender, sync_channel},
     },
     thread,
@@ -10,23 +12,31 @@ use std::{
 };
 
 use anyhow::{Result, anyhow};
+use cosmic_text::Weight;
 use ffmpeg_next::{Rational, Rescale, frame};
 use sdl2::{
     Sdl, VideoSubsystem,
     audio::{AudioQueue, AudioSpecDesired},
-    event::Event,
+    event::{Event, WindowEvent},
     keyboard::Keycode,
+    mouse::MouseButton,
     pixels::{Color, PixelFormatEnum},
     rect::Rect,
-    render::{Canvas, Texture},
+    render::{BlendMode, Canvas, Texture},
+    sys,
     video::{FullscreenType, Window},
 };
 
+use super::vtt;
 use super::{FrameOutput, PlaybackStopped};
 use crate::{
     analysis::audio_level::{AudioLevelCallback, AudioLevelMeter},
     audio_mixer::{AudioEffectChain, AudioEffectsControl},
-    utils::config::OutputConfig,
+    compositor::{
+        logo::{LogoOverlay, logo_position},
+        text::{render_plain_text_bitmap, render_wrapped_text_bitmap},
+    },
+    utils::config::{OutputConfig, RgbaColor},
 };
 
 const AUDIO_CHANNELS: usize = 2;
@@ -37,11 +47,36 @@ const VIDEO_PREBUFFER_FRAMES: usize = 3;
 const VIDEO_DROP_THRESHOLD_FRAMES: i64 = 3;
 const VIDEO_STARVATION_GRACE_FRAMES: i64 = 2;
 const SCHEDULER_INTERVAL: Duration = Duration::from_millis(2);
-const OUTPUT_CHANNEL_CAPACITY: usize = 64;
+const OUTPUT_CHANNEL_CAPACITY: usize = 8;
 const DESKTOP_VOLUME_STEP: f64 = 0.05;
 const DESKTOP_VOLUME_MIN: f64 = 0.0;
 const DESKTOP_VOLUME_MAX: f64 = 1.5;
 const VOLUME_OVERLAY_DURATION: Duration = Duration::from_millis(900);
+const TITLEBAR_IDLE_TIMEOUT: Duration = Duration::from_secs(3);
+const TITLEBAR_HEIGHT: u32 = 28;
+const TITLEBAR_CLOSE_MARGIN: u32 = 4;
+const TITLEBAR_BUTTON_GAP: u32 = 4;
+const TITLEBAR_TITLE: &str = "ffplayout";
+const WINDOW_RESIZE_BORDER: i32 = 8;
+const WINDOW_ASPECT_SETTLE: Duration = Duration::from_millis(120);
+const SUBTITLE_FONT_SIZE: f32 = 24.0;
+const SUBTITLE_FULLSCREEN_FONT_SIZE: f32 = 44.0;
+const SUBTITLE_OUTLINE: u32 = 2;
+const SUBTITLE_MARGIN_BOTTOM: u32 = 56;
+const SUBTITLE_MAX_WIDTH_PERCENT: u32 = 92;
+const DOUBLE_CLICK_MIN_INTERVAL: Duration = Duration::from_millis(80);
+const DOUBLE_CLICK_MAX_INTERVAL: Duration = Duration::from_millis(450);
+const DOUBLE_CLICK_MAX_DISTANCE: i32 = 6;
+
+static HIT_TEST_STATE: OnceLock<Mutex<HitTestState>> = OnceLock::new();
+static HIT_TEST_DOUBLE_CLICK: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Default)]
+struct HitTestState {
+    last_at: Option<Instant>,
+    last_x: i32,
+    last_y: i32,
+}
 
 fn video_prebuffer_ready(queue_len: usize, video_finished: bool, force: bool) -> bool {
     force || video_finished || queue_len >= VIDEO_PREBUFFER_FRAMES
@@ -49,6 +84,12 @@ fn video_prebuffer_ready(queue_len: usize, video_finished: bool, force: bool) ->
 
 fn input_can_pause(video_queue_len: usize, video_finished: bool) -> bool {
     video_finished || video_queue_len >= VIDEO_PREBUFFER_FRAMES
+}
+
+fn scaled_aspect_dimension(value: u32, numerator: u32, denominator: u32) -> u32 {
+    ((u64::from(value) * u64::from(numerator) + (u64::from(denominator) / 2))
+        / u64::from(denominator))
+    .max(1) as u32
 }
 
 fn video_frame_is_too_late(frame_pts: i64, expected_pts: i64, queue_len: usize) -> bool {
@@ -64,20 +105,32 @@ pub(super) struct DesktopOutput {
 
 enum DesktopMessage {
     ClipStarted,
-    Video(frame::Video),
+    VideoWithLogo {
+        frame: frame::Video,
+        logo_opacity: f64,
+    },
     Audio {
         samples: Vec<f32>,
         samples_per_channel: usize,
     },
+    Subtitles(Vec<DesktopSubtitleCue>),
     VideoEnd(Option<i64>),
     VideoFinished,
     ClipFinished,
+}
+
+#[derive(Debug, Clone)]
+struct DesktopSubtitleCue {
+    start_ms: i64,
+    end_ms: i64,
+    text: String,
 }
 
 pub(crate) struct DesktopFrameSender {
     sender: SyncSender<DesktopMessage>,
     audio_effects: Arc<Mutex<AudioEffectChain>>,
     audio_level_meter: AudioLevelMeter,
+    current_logo_opacity: f64,
 }
 
 pub(crate) struct DesktopSdl {
@@ -88,6 +141,7 @@ pub(crate) struct DesktopSdl {
 struct DesktopRenderer {
     // Texture must be dropped before its parent canvas.
     texture: Texture,
+    title_texture: Option<TitleTexture>,
     canvas: Canvas<Window>,
     audio: AudioQueue<f32>,
     audio_effects_control: AudioEffectsControl,
@@ -106,10 +160,38 @@ struct DesktopRenderer {
     last_rendered_video_pts: Option<i64>,
     last_video_present: Option<Instant>,
     last_starvation_report: Option<Instant>,
+    fps: u32,
+    subtitles_enabled: bool,
+    subtitles: Vec<DesktopSubtitleCue>,
+    active_subtitle_text: Option<String>,
+    subtitle_texture: Option<TitleTexture>,
+    logo_texture: Option<DesktopLogoTexture>,
+    current_logo_opacity: f64,
     fullscreen: bool,
+    aspect_width: u32,
+    aspect_height: u32,
+    last_window_size: (u32, u32),
+    pending_aspect_resize: Option<(u32, u32, Instant)>,
+    window_active: bool,
+    mouse_over_window: bool,
+    last_mouse_motion: Option<Instant>,
     volume_overlay_until: Option<Instant>,
     // SDL context must outlive all resources above.
     _sdl: Sdl,
+}
+
+struct TitleTexture {
+    texture: Texture,
+    width: u32,
+    height: u32,
+}
+
+struct DesktopLogoTexture {
+    texture: Texture,
+    width: u32,
+    height: u32,
+    position: String,
+    opacity: u8,
 }
 
 impl DesktopOutput {
@@ -160,6 +242,7 @@ impl DesktopOutput {
                         audio_sample_rate,
                         audio_level_callback,
                     ),
+                    current_logo_opacity: 0.0,
                 };
                 let _ = output.sender.send(DesktopMessage::ClipStarted);
                 let result = operation(&mut output);
@@ -201,8 +284,20 @@ impl FrameOutput for DesktopFrameSender {
 
     fn encode_video(&mut self, frame: &frame::Video) -> Result<()> {
         self.sender
-            .send(DesktopMessage::Video(frame.clone()))
+            .send(DesktopMessage::VideoWithLogo {
+                frame: frame.clone(),
+                logo_opacity: self.current_logo_opacity,
+            })
             .map_err(|_| PlaybackStopped.into())
+    }
+
+    fn apply_logo_overlay(
+        &mut self,
+        _frame: &mut frame::Video,
+        _logo: &LogoOverlay,
+        opacity_factor: f64,
+    ) {
+        self.current_logo_opacity = opacity_factor;
     }
 
     fn encode_audio(&mut self, frame: &frame::Audio) -> Result<()> {
@@ -237,6 +332,36 @@ impl FrameOutput for DesktopFrameSender {
             .map_err(|_| PlaybackStopped.into())
     }
 
+    fn write_vtt_subtitles(
+        &mut self,
+        media_path: &str,
+        output_start_ms: i64,
+        source_start_ms: i64,
+    ) -> Result<()> {
+        let vtt_path = vtt::sidecar_path(media_path);
+        if !vtt_path.exists() {
+            return Ok(());
+        }
+
+        let subtitles = vtt::parse_file(&vtt_path)?
+            .into_iter()
+            .filter(|cue| cue.end_ms > source_start_ms)
+            .map(|cue| {
+                let cue_start_ms = cue.start_ms.saturating_sub(source_start_ms);
+                let cue_end_ms = cue.end_ms - source_start_ms;
+                DesktopSubtitleCue {
+                    start_ms: output_start_ms + cue_start_ms,
+                    end_ms: output_start_ms + cue_end_ms,
+                    text: cue.text,
+                }
+            })
+            .collect();
+
+        self.sender
+            .send(DesktopMessage::Subtitles(subtitles))
+            .map_err(|_| PlaybackStopped.into())
+    }
+
     fn video_finished(&mut self) -> Result<()> {
         self.sender
             .send(DesktopMessage::VideoFinished)
@@ -250,17 +375,31 @@ impl DesktopRenderer {
         let audio_subsystem = sdl.audio().map_err(anyhow::Error::msg)?;
         let (window_width, window_height) =
             cfg.desktop_window_size.unwrap_or((cfg.width, cfg.height));
-        let window = video
+        let mut window = video
             .window("ffplayout", window_width, window_height)
             .position_centered()
+            .borderless()
             .resizable()
             .build()
             .map_err(|error| anyhow!("{error}"))?;
-        let canvas = window
+        if cfg.desktop_fullscreen {
+            window
+                .set_fullscreen(FullscreenType::Desktop)
+                .map_err(|error| anyhow!("{error}"))?;
+        }
+        install_window_hit_test(&window);
+        let mut canvas = window
             .into_canvas()
             .accelerated()
             .build()
             .map_err(|error| anyhow!("{error}"))?;
+        canvas.set_blend_mode(BlendMode::Blend);
+        let title_texture = create_title_texture(&canvas)?;
+        let logo_texture = cfg
+            .logo
+            .as_ref()
+            .map(|logo| create_desktop_logo_texture(&canvas, logo, cfg.width, cfg.height))
+            .transpose()?;
         let texture = canvas
             .texture_creator()
             .create_texture_streaming(PixelFormatEnum::IYUV, cfg.width, cfg.height)
@@ -287,6 +426,7 @@ impl DesktopRenderer {
 
         Ok(Self {
             canvas,
+            title_texture,
             audio,
             audio_effects_control: cfg.audio_effects.clone(),
             event_pump,
@@ -295,6 +435,7 @@ impl DesktopRenderer {
             pending_audio_samples: 0,
             submitted_audio_samples: 0,
             audio_started: false,
+            fps: cfg.fps,
             sample_rate: cfg.sample_rate,
             device_buffer_samples,
             audio_clock: AudioMasterClock::new(cfg.sample_rate, device_buffer_samples),
@@ -304,7 +445,20 @@ impl DesktopRenderer {
             last_rendered_video_pts: None,
             last_video_present: None,
             last_starvation_report: None,
-            fullscreen: false,
+            subtitles_enabled: true,
+            subtitles: Vec::new(),
+            active_subtitle_text: None,
+            subtitle_texture: None,
+            logo_texture,
+            current_logo_opacity: 0.0,
+            fullscreen: cfg.desktop_fullscreen,
+            aspect_width: window_width.max(1),
+            aspect_height: window_height.max(1),
+            last_window_size: (window_width, window_height),
+            pending_aspect_resize: None,
+            window_active: true,
+            mouse_over_window: false,
+            last_mouse_motion: None,
             volume_overlay_until: None,
             texture,
             _sdl: sdl,
@@ -314,6 +468,7 @@ impl DesktopRenderer {
     fn run_clip(&mut self, receiver: Receiver<DesktopMessage>) -> Result<()> {
         loop {
             self.handle_events()?;
+            self.apply_pending_window_aspect_constraint()?;
             self.flush_pending_audio()?;
             self.render_due_video()?;
 
@@ -329,8 +484,15 @@ impl DesktopRenderer {
                     self.video_end_pts = None;
                     self.video_finished = false;
                     self.last_starvation_report = None;
+                    self.subtitles.clear();
+                    self.active_subtitle_text = None;
+                    self.subtitle_texture = None;
                 }
-                Ok(DesktopMessage::Video(frame)) => {
+                Ok(DesktopMessage::VideoWithLogo {
+                    frame,
+                    logo_opacity,
+                }) => {
+                    self.current_logo_opacity = logo_opacity;
                     self.video_queue.push_back(frame);
                     self.start_audio_if_ready(false);
                 }
@@ -343,6 +505,11 @@ impl DesktopRenderer {
                         .pending_audio_samples
                         .saturating_add(samples_per_channel as u64);
                     self.flush_pending_audio()?;
+                }
+                Ok(DesktopMessage::Subtitles(subtitles)) => {
+                    self.subtitles = subtitles;
+                    self.active_subtitle_text = None;
+                    self.subtitle_texture = None;
                 }
                 Ok(DesktopMessage::VideoEnd(video_end_pts)) => {
                     self.video_end_pts = video_end_pts;
@@ -536,6 +703,9 @@ impl DesktopRenderer {
         self.canvas
             .copy(&self.texture, None, None)
             .map_err(anyhow::Error::msg)?;
+        self.draw_logo_overlay()?;
+        self.draw_subtitle_overlay(frame.pts().unwrap_or_default())?;
+        self.draw_titlebar()?;
         self.draw_volume_overlay()?;
         self.canvas.present();
         Ok(())
@@ -544,6 +714,9 @@ impl DesktopRenderer {
     fn render_black_frame(&mut self) {
         self.canvas.set_draw_color(Color::RGB(0, 0, 0));
         self.canvas.clear();
+        let _ = self.draw_logo_overlay();
+        let _ = self.draw_subtitle_overlay(self.last_rendered_video_pts.unwrap_or_default());
+        let _ = self.draw_titlebar();
         let _ = self.draw_volume_overlay();
         self.canvas.present();
     }
@@ -576,11 +749,75 @@ impl DesktopRenderer {
         while let Some(event) = self.event_pump.poll_event() {
             match event {
                 Event::Quit { .. } => return Err(PlaybackStopped.into()),
+                Event::Window {
+                    win_event: WindowEvent::FocusGained,
+                    ..
+                } => self.window_active = true,
+                Event::Window {
+                    win_event: WindowEvent::FocusLost,
+                    ..
+                } => self.window_active = false,
+                Event::Window {
+                    win_event: WindowEvent::Enter,
+                    ..
+                } => {
+                    self.mouse_over_window = true;
+                    self.last_mouse_motion = Some(Instant::now());
+                }
+                Event::Window {
+                    win_event: WindowEvent::Leave,
+                    ..
+                } => {
+                    self.mouse_over_window = false;
+                    self.last_mouse_motion = None;
+                }
+                Event::Window {
+                    win_event: WindowEvent::Resized(width, height),
+                    ..
+                }
+                | Event::Window {
+                    win_event: WindowEvent::SizeChanged(width, height),
+                    ..
+                } => {
+                    self.queue_window_aspect_constraint(width, height);
+                }
+                Event::MouseMotion { .. } => {
+                    self.last_mouse_motion = Some(Instant::now());
+                }
+                Event::MouseButtonDown {
+                    mouse_btn: MouseButton::Left,
+                    clicks,
+                    x,
+                    y,
+                    ..
+                } if self.titlebar_visible() => match titlebar_button_hit(
+                    self.canvas.output_size().map_err(anyhow::Error::msg)?,
+                    x,
+                    y,
+                ) {
+                    Some(TitlebarButton::Close) => return Err(PlaybackStopped.into()),
+                    Some(TitlebarButton::Fullscreen) => self.toggle_fullscreen()?,
+                    Some(TitlebarButton::Minimize) => self.canvas.window_mut().minimize(),
+                    None if clicks >= 2 || take_hit_test_double_click() => {
+                        self.toggle_fullscreen()?;
+                    }
+                    None => {}
+                },
+                Event::MouseButtonDown {
+                    mouse_btn: MouseButton::Left,
+                    clicks,
+                    ..
+                } if clicks >= 2 || take_hit_test_double_click() => self.toggle_fullscreen()?,
                 Event::KeyDown {
                     keycode: Some(Keycode::F),
                     repeat: false,
                     ..
                 } => self.toggle_fullscreen()?,
+                Event::KeyDown {
+                    keycode: Some(Keycode::S),
+                    repeat: false,
+                    ..
+                } => self.toggle_subtitles(),
                 Event::KeyDown {
                     keycode: Some(Keycode::Left),
                     ..
@@ -596,6 +833,57 @@ impl DesktopRenderer {
                 _ => {}
             }
         }
+        self.apply_pending_window_aspect_constraint()?;
+        Ok(())
+    }
+
+    fn toggle_subtitles(&mut self) {
+        self.subtitles_enabled = !self.subtitles_enabled;
+        self.active_subtitle_text = None;
+        self.subtitle_texture = None;
+    }
+
+    fn queue_window_aspect_constraint(&mut self, width: i32, height: i32) {
+        if self.fullscreen || width <= 0 || height <= 0 {
+            return;
+        }
+
+        self.pending_aspect_resize = Some((width as u32, height as u32, Instant::now()));
+    }
+
+    fn apply_pending_window_aspect_constraint(&mut self) -> Result<()> {
+        let Some((width, height, at)) = self.pending_aspect_resize else {
+            return Ok(());
+        };
+        if Instant::now().duration_since(at) < WINDOW_ASPECT_SETTLE {
+            return Ok(());
+        }
+
+        self.pending_aspect_resize = None;
+        let (last_width, last_height) = self.last_window_size;
+        let width_delta = width.abs_diff(last_width);
+        let height_delta = height.abs_diff(last_height);
+
+        let target = if width_delta >= height_delta {
+            (
+                width,
+                scaled_aspect_dimension(width, self.aspect_height, self.aspect_width),
+            )
+        } else {
+            (
+                scaled_aspect_dimension(height, self.aspect_width, self.aspect_height),
+                height,
+            )
+        };
+
+        self.last_window_size = target;
+        if target != (width, height) {
+            self.canvas
+                .window_mut()
+                .set_size(target.0, target.1)
+                .map_err(|error| anyhow!("{error}"))?;
+        }
+
         Ok(())
     }
 
@@ -621,7 +909,192 @@ impl DesktopRenderer {
             .set_fullscreen(mode)
             .map_err(anyhow::Error::msg)?;
         self.fullscreen = fullscreen;
+        self.active_subtitle_text = None;
+        self.subtitle_texture = None;
         Ok(())
+    }
+
+    fn titlebar_visible(&self) -> bool {
+        self.window_active
+            && self.mouse_over_window
+            && self
+                .last_mouse_motion
+                .is_some_and(|last| Instant::now().duration_since(last) < TITLEBAR_IDLE_TIMEOUT)
+    }
+
+    fn draw_subtitle_overlay(&mut self, video_pts: i64) -> Result<()> {
+        self.update_subtitle_texture(video_pts)?;
+
+        let Some(subtitle) = &self.subtitle_texture else {
+            return Ok(());
+        };
+
+        let (width, height) = self.canvas.output_size().map_err(anyhow::Error::msg)?;
+        let x = ((width.saturating_sub(subtitle.width)) / 2) as i32;
+        let y = height.saturating_sub(subtitle.height + SUBTITLE_MARGIN_BOTTOM) as i32;
+
+        self.canvas
+            .copy(
+                &subtitle.texture,
+                None,
+                Rect::new(x, y, subtitle.width, subtitle.height),
+            )
+            .map_err(anyhow::Error::msg)
+    }
+
+    fn update_subtitle_texture(&mut self, video_pts: i64) -> Result<()> {
+        let text = self.active_subtitle_for_pts(video_pts);
+
+        if self.active_subtitle_text.as_deref() == text.as_deref() {
+            return Ok(());
+        }
+
+        self.active_subtitle_text = text.clone();
+        self.subtitle_texture = match text {
+            Some(text) => Some(create_subtitle_texture(
+                &self.canvas,
+                &text,
+                self.fullscreen,
+            )?),
+            None => None,
+        };
+
+        Ok(())
+    }
+
+    fn active_subtitle_for_pts(&self, video_pts: i64) -> Option<String> {
+        if !self.subtitles_enabled {
+            return None;
+        }
+
+        let ms = video_pts.saturating_mul(1_000) / i64::from(self.fps);
+        self.subtitles
+            .iter()
+            .find(|cue| cue.start_ms <= ms && ms < cue.end_ms)
+            .map(|cue| cue.text.clone())
+    }
+
+    fn draw_logo_overlay(&mut self) -> Result<()> {
+        let (canvas_width, canvas_height) =
+            self.canvas.output_size().map_err(anyhow::Error::msg)?;
+        let (window_width, window_height) = self.canvas.window().size();
+        let Some(logo) = &mut self.logo_texture else {
+            return Ok(());
+        };
+
+        let alpha = (f64::from(logo.opacity) * self.current_logo_opacity)
+            .round()
+            .clamp(0.0, 255.0) as u8;
+        if alpha == 0 {
+            return Ok(());
+        }
+
+        let (x, y) = logo_position(
+            &logo.position,
+            window_width,
+            window_height,
+            logo.width,
+            logo.height,
+        )?;
+        let scale_x = f64::from(canvas_width) / f64::from(window_width.max(1));
+        let scale_y = f64::from(canvas_height) / f64::from(window_height.max(1));
+        let dst = Rect::new(
+            (f64::from(x) * scale_x).round() as i32,
+            (f64::from(y) * scale_y).round() as i32,
+            (f64::from(logo.width) * scale_x).round().max(1.0) as u32,
+            (f64::from(logo.height) * scale_y).round().max(1.0) as u32,
+        );
+        logo.texture.set_alpha_mod(alpha);
+        self.canvas
+            .copy(&logo.texture, None, dst)
+            .map_err(anyhow::Error::msg)
+    }
+
+    fn draw_titlebar(&mut self) -> Result<()> {
+        if !self.titlebar_visible() {
+            return Ok(());
+        }
+
+        let (width, _) = self.canvas.output_size().map_err(anyhow::Error::msg)?;
+        let titlebar = Rect::new(0, 0, width, TITLEBAR_HEIGHT);
+
+        self.canvas.set_draw_color(Color::RGB(14, 16, 18));
+        self.canvas
+            .fill_rect(titlebar)
+            .map_err(anyhow::Error::msg)?;
+        self.draw_titlebar_text(width)?;
+        self.canvas.set_draw_color(Color::RGB(218, 218, 218));
+        self.draw_minimize_icon(titlebar_button_rect(width, TitlebarButton::Minimize))?;
+        self.draw_fullscreen_icon(titlebar_button_rect(width, TitlebarButton::Fullscreen))?;
+        self.draw_close_icon(titlebar_button_rect(width, TitlebarButton::Close))?;
+        Ok(())
+    }
+
+    fn draw_titlebar_text(&mut self, width: u32) -> Result<()> {
+        let Some(title) = &self.title_texture else {
+            return Ok(());
+        };
+
+        let x = ((width.saturating_sub(title.width)) / 2) as i32;
+        let y = ((TITLEBAR_HEIGHT.saturating_sub(title.height)) / 2) as i32 + 2;
+        let first_button = titlebar_button_rect(width, TitlebarButton::Minimize);
+
+        if x < 10 || x + title.width as i32 >= first_button.x - 10 {
+            return Ok(());
+        }
+
+        self.canvas
+            .copy(
+                &title.texture,
+                None,
+                Rect::new(x, y, title.width, title.height),
+            )
+            .map_err(anyhow::Error::msg)
+    }
+
+    fn draw_minimize_icon(&mut self, rect: Rect) -> Result<()> {
+        let y = rect.y + rect.height() as i32 - 7;
+        self.canvas
+            .fill_rect(Rect::new(rect.x + 5, y, rect.width() - 10, 2))
+            .map_err(anyhow::Error::msg)
+    }
+
+    fn draw_fullscreen_icon(&mut self, rect: Rect) -> Result<()> {
+        let x = rect.x + 5;
+        let y = rect.y + 5;
+        let size = rect.width() - 10;
+
+        self.canvas
+            .draw_rect(Rect::new(x, y, size, size))
+            .map_err(anyhow::Error::msg)?;
+        self.canvas
+            .draw_rect(Rect::new(
+                x + 1,
+                y + 1,
+                size.saturating_sub(2),
+                size.saturating_sub(2),
+            ))
+            .map_err(anyhow::Error::msg)
+    }
+
+    fn draw_close_icon(&mut self, rect: Rect) -> Result<()> {
+        let left = rect.x + 6;
+        let right = rect.x + rect.width() as i32 - 6;
+        let top = rect.y + 6;
+        let bottom = rect.y + rect.height() as i32 - 6;
+
+        self.canvas
+            .draw_line((left, top), (right, bottom))
+            .map_err(anyhow::Error::msg)?;
+        self.canvas
+            .draw_line((left + 1, top), (right + 1, bottom))
+            .map_err(anyhow::Error::msg)?;
+        self.canvas
+            .draw_line((right, top), (left, bottom))
+            .map_err(anyhow::Error::msg)?;
+        self.canvas
+            .draw_line((right + 1, top), (left + 1, bottom))
+            .map_err(anyhow::Error::msg)
     }
 
     fn draw_volume_overlay(&mut self) -> Result<()> {
@@ -664,13 +1137,381 @@ impl DesktopRenderer {
     }
 }
 
+fn install_window_hit_test(window: &Window) {
+    // Best effort: unsupported platforms simply keep the borderless window
+    // without compositor-assisted dragging.
+    unsafe {
+        sys::SDL_SetWindowHitTest(window.raw(), Some(desktop_hit_test), std::ptr::null_mut());
+    }
+}
+
+extern "C" fn desktop_hit_test(
+    window: *mut sys::SDL_Window,
+    area: *const sys::SDL_Point,
+    _data: *mut c_void,
+) -> sys::SDL_HitTestResult {
+    if window.is_null() || area.is_null() {
+        return sys::SDL_HitTestResult::SDL_HITTEST_NORMAL;
+    }
+
+    let point = unsafe { *area };
+    let mut width = 0;
+    let mut height = 0;
+    unsafe {
+        sys::SDL_GetWindowSize(window, &mut width, &mut height);
+    }
+
+    if let Some(resize) = resize_hit_test(window, width, height, point.x, point.y) {
+        return resize;
+    }
+
+    if titlebar_button_hit(
+        (width.max(0) as u32, height.max(0) as u32),
+        point.x,
+        point.y,
+    )
+    .is_some()
+    {
+        return sys::SDL_HitTestResult::SDL_HITTEST_NORMAL;
+    }
+
+    if detect_hit_test_double_click(point.x, point.y) {
+        HIT_TEST_DOUBLE_CLICK.store(true, Ordering::Relaxed);
+        return sys::SDL_HitTestResult::SDL_HITTEST_NORMAL;
+    }
+
+    sys::SDL_HitTestResult::SDL_HITTEST_DRAGGABLE
+}
+
+fn resize_hit_test(
+    window: *mut sys::SDL_Window,
+    width: i32,
+    height: i32,
+    x: i32,
+    y: i32,
+) -> Option<sys::SDL_HitTestResult> {
+    if width <= 0 || height <= 0 {
+        return None;
+    }
+
+    let flags = unsafe { sys::SDL_GetWindowFlags(window) };
+    if flags & sys::SDL_WindowFlags::SDL_WINDOW_FULLSCREEN_DESKTOP as u32 != 0 {
+        return None;
+    }
+
+    let left = x < WINDOW_RESIZE_BORDER;
+    let right = x >= width.saturating_sub(WINDOW_RESIZE_BORDER);
+    let top = y < WINDOW_RESIZE_BORDER;
+    let bottom = y >= height.saturating_sub(WINDOW_RESIZE_BORDER);
+
+    match (left, right, top, bottom) {
+        (true, _, true, _) => Some(sys::SDL_HitTestResult::SDL_HITTEST_RESIZE_TOPLEFT),
+        (_, true, true, _) => Some(sys::SDL_HitTestResult::SDL_HITTEST_RESIZE_TOPRIGHT),
+        (true, _, _, true) => Some(sys::SDL_HitTestResult::SDL_HITTEST_RESIZE_BOTTOMLEFT),
+        (_, true, _, true) => Some(sys::SDL_HitTestResult::SDL_HITTEST_RESIZE_BOTTOMRIGHT),
+        (true, _, _, _) => Some(sys::SDL_HitTestResult::SDL_HITTEST_RESIZE_LEFT),
+        (_, true, _, _) => Some(sys::SDL_HitTestResult::SDL_HITTEST_RESIZE_RIGHT),
+        (_, _, true, _) => Some(sys::SDL_HitTestResult::SDL_HITTEST_RESIZE_TOP),
+        (_, _, _, true) => Some(sys::SDL_HitTestResult::SDL_HITTEST_RESIZE_BOTTOM),
+        _ => None,
+    }
+}
+
+fn detect_hit_test_double_click(x: i32, y: i32) -> bool {
+    let now = Instant::now();
+    let state = HIT_TEST_STATE.get_or_init(|| Mutex::new(HitTestState::default()));
+    let Ok(mut state) = state.lock() else {
+        return false;
+    };
+
+    let is_double_click = state.last_at.is_some_and(|last| {
+        let elapsed = now.duration_since(last);
+        elapsed >= DOUBLE_CLICK_MIN_INTERVAL
+            && elapsed <= DOUBLE_CLICK_MAX_INTERVAL
+            && (state.last_x - x).abs() <= DOUBLE_CLICK_MAX_DISTANCE
+            && (state.last_y - y).abs() <= DOUBLE_CLICK_MAX_DISTANCE
+    });
+
+    state.last_at = Some(now);
+    state.last_x = x;
+    state.last_y = y;
+    is_double_click
+}
+
+fn take_hit_test_double_click() -> bool {
+    HIT_TEST_DOUBLE_CLICK.swap(false, Ordering::Relaxed)
+}
+
+#[derive(Debug, Clone, Copy)]
+enum TitlebarButton {
+    Minimize,
+    Fullscreen,
+    Close,
+}
+
+fn titlebar_button_rect(window_width: u32, button: TitlebarButton) -> Rect {
+    let size = TITLEBAR_HEIGHT.saturating_sub(TITLEBAR_CLOSE_MARGIN * 2);
+    let index_from_right = match button {
+        TitlebarButton::Close => 0,
+        TitlebarButton::Fullscreen => 1,
+        TitlebarButton::Minimize => 2,
+    };
+    let offset = TITLEBAR_CLOSE_MARGIN + index_from_right * (size + TITLEBAR_BUTTON_GAP);
+    let x = window_width.saturating_sub(size + offset) as i32;
+
+    Rect::new(x, TITLEBAR_CLOSE_MARGIN as i32, size, size)
+}
+
+fn titlebar_button_hit((window_width, _): (u32, u32), x: i32, y: i32) -> Option<TitlebarButton> {
+    [
+        TitlebarButton::Minimize,
+        TitlebarButton::Fullscreen,
+        TitlebarButton::Close,
+    ]
+    .into_iter()
+    .find(|button| titlebar_button_rect(window_width, *button).contains_point((x, y)))
+}
+
+fn create_title_texture(canvas: &Canvas<Window>) -> Result<Option<TitleTexture>> {
+    Ok(Some(create_text_texture(
+        canvas,
+        TITLEBAR_TITLE,
+        14.0,
+        Weight::SEMIBOLD,
+        RgbaColor {
+            r: 218,
+            g: 218,
+            b: 218,
+            a: 255,
+        },
+    )?))
+}
+
+fn create_desktop_logo_texture(
+    canvas: &Canvas<Window>,
+    config: &crate::utils::config::LogoConfig,
+    output_width: u32,
+    output_height: u32,
+) -> Result<DesktopLogoTexture> {
+    let logo = LogoOverlay::load(config, output_width, output_height)?;
+    let pixels = yuva420p_to_rgba(&logo);
+    let texture_creator = canvas.texture_creator();
+    let mut texture = texture_creator
+        .create_texture_static(PixelFormatEnum::RGBA32, logo.width, logo.height)
+        .map_err(|error| anyhow!("{error}"))?;
+
+    texture.set_blend_mode(BlendMode::Blend);
+    texture
+        .update(None, &pixels, logo.width as usize * 4)
+        .map_err(|error| anyhow!("{error}"))?;
+
+    Ok(DesktopLogoTexture {
+        texture,
+        width: logo.width,
+        height: logo.height,
+        position: config.position.clone(),
+        opacity: logo.opacity,
+    })
+}
+
+fn yuva420p_to_rgba(logo: &LogoOverlay) -> Vec<u8> {
+    let width = logo.width as usize;
+    let height = logo.height as usize;
+    let y_plane = logo.frame.data(0);
+    let u_plane = logo.frame.data(1);
+    let v_plane = logo.frame.data(2);
+    let a_plane = logo.frame.data(3);
+    let y_stride = logo.frame.stride(0);
+    let u_stride = logo.frame.stride(1);
+    let v_stride = logo.frame.stride(2);
+    let a_stride = logo.frame.stride(3);
+    let mut pixels = vec![0_u8; width * height * 4];
+
+    for y in 0..height {
+        for x in 0..width {
+            let yy = i32::from(y_plane[y * y_stride + x]);
+            let uu = i32::from(u_plane[(y / 2) * u_stride + (x / 2)]);
+            let vv = i32::from(v_plane[(y / 2) * v_stride + (x / 2)]);
+            let aa = a_plane[y * a_stride + x];
+            let (r, g, b) = yuv_to_rgb(yy, uu, vv);
+            let dst = (y * width + x) * 4;
+            pixels[dst] = r;
+            pixels[dst + 1] = g;
+            pixels[dst + 2] = b;
+            pixels[dst + 3] = aa;
+        }
+    }
+
+    pixels
+}
+
+fn yuv_to_rgb(y: i32, u: i32, v: i32) -> (u8, u8, u8) {
+    let c = y.saturating_sub(16);
+    let d = u - 128;
+    let e = v - 128;
+    (
+        clamp_rgb((298 * c + 409 * e + 128) >> 8),
+        clamp_rgb((298 * c - 100 * d - 208 * e + 128) >> 8),
+        clamp_rgb((298 * c + 516 * d + 128) >> 8),
+    )
+}
+
+fn clamp_rgb(value: i32) -> u8 {
+    value.clamp(0, 255) as u8
+}
+
+fn create_subtitle_texture(
+    canvas: &Canvas<Window>,
+    text: &str,
+    fullscreen: bool,
+) -> Result<TitleTexture> {
+    let (window_width, _) = canvas.output_size().map_err(anyhow::Error::msg)?;
+    let max_width = (window_width * SUBTITLE_MAX_WIDTH_PERCENT / 100).max(1);
+    let font_size = if fullscreen {
+        SUBTITLE_FULLSCREEN_FONT_SIZE
+    } else {
+        SUBTITLE_FONT_SIZE
+    };
+    let text_width = max_width.saturating_sub(SUBTITLE_OUTLINE * 2).max(1);
+    let white = render_wrapped_text_bitmap(
+        text,
+        font_size,
+        Weight::SEMIBOLD,
+        RgbaColor {
+            r: 248,
+            g: 248,
+            b: 248,
+            a: 255,
+        },
+        text_width,
+    )?;
+    let black = render_wrapped_text_bitmap(
+        text,
+        font_size,
+        Weight::SEMIBOLD,
+        RgbaColor {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 230,
+        },
+        text_width,
+    )?;
+    let width = white.width + SUBTITLE_OUTLINE * 2;
+    let height = white.height + SUBTITLE_OUTLINE * 2;
+    let mut pixels = vec![0_u8; width as usize * height as usize * 4];
+
+    let outline = SUBTITLE_OUTLINE as i32;
+    for y in -outline..=outline {
+        for x in -outline..=outline {
+            if x == 0 && y == 0 {
+                continue;
+            }
+            let distance = ((x * x + y * y) as f32).sqrt();
+            if distance > outline as f32 + 0.25 {
+                continue;
+            }
+            let alpha = (1.0 - (distance / (outline as f32 + 0.75))).clamp(0.25, 1.0);
+            composite_bitmap(&mut pixels, width, &black, outline + x, outline + y, alpha);
+        }
+    }
+    composite_bitmap(
+        &mut pixels,
+        width,
+        &white,
+        SUBTITLE_OUTLINE as i32,
+        SUBTITLE_OUTLINE as i32,
+        1.0,
+    );
+
+    create_texture_from_rgba(canvas, pixels, width, height)
+}
+
+fn create_text_texture(
+    canvas: &Canvas<Window>,
+    text: &str,
+    font_size: f32,
+    font_weight: Weight,
+    color: RgbaColor,
+) -> Result<TitleTexture> {
+    let bitmap = render_plain_text_bitmap(text, font_size, font_weight, color)?;
+    create_texture_from_rgba(canvas, bitmap.pixels, bitmap.width, bitmap.height)
+}
+
+fn create_texture_from_rgba(
+    canvas: &Canvas<Window>,
+    pixels: Vec<u8>,
+    width: u32,
+    height: u32,
+) -> Result<TitleTexture> {
+    let texture_creator = canvas.texture_creator();
+    let mut texture = texture_creator
+        .create_texture_static(PixelFormatEnum::RGBA32, width, height)
+        .map_err(|error| anyhow!("{error}"))?;
+
+    texture.set_blend_mode(BlendMode::Blend);
+    texture
+        .update(None, &pixels, width as usize * 4)
+        .map_err(|error| anyhow!("{error}"))?;
+
+    Ok(TitleTexture {
+        texture,
+        width,
+        height,
+    })
+}
+
+fn composite_bitmap(
+    dst: &mut [u8],
+    dst_width: u32,
+    src: &crate::compositor::text::TextBitmap,
+    x: i32,
+    y: i32,
+    alpha_scale: f32,
+) {
+    let dst_width = dst_width as usize;
+    for sy in 0..src.height as usize {
+        let dy = y + sy as i32;
+        if dy < 0 {
+            continue;
+        }
+
+        for sx in 0..src.width as usize {
+            let dx = x + sx as i32;
+            if dx < 0 {
+                continue;
+            }
+
+            let dst_idx = (dy as usize * dst_width + dx as usize) * 4;
+            let src_idx = (sy * src.width as usize + sx) * 4;
+            if dst_idx + 4 <= dst.len() {
+                let src_pixel = [
+                    src.pixels[src_idx],
+                    src.pixels[src_idx + 1],
+                    src.pixels[src_idx + 2],
+                    ((src.pixels[src_idx + 3] as f32) * alpha_scale).round() as u8,
+                ];
+                alpha_composite_rgba(&mut dst[dst_idx..dst_idx + 4], &src_pixel);
+            }
+        }
+    }
+}
+
+fn alpha_composite_rgba(dst: &mut [u8], src: &[u8]) {
+    let alpha = u16::from(src[3]);
+    let inv_alpha = 255 - alpha;
+    dst[0] = (((u16::from(dst[0]) * inv_alpha) + (u16::from(src[0]) * alpha) + 127) / 255) as u8;
+    dst[1] = (((u16::from(dst[1]) * inv_alpha) + (u16::from(src[1]) * alpha) + 127) / 255) as u8;
+    dst[2] = (((u16::from(dst[2]) * inv_alpha) + (u16::from(src[2]) * alpha) + 127) / 255) as u8;
+    dst[3] = (u16::from(dst[3]) + alpha - ((u16::from(dst[3]) * alpha + 127) / 255)) as u8;
+}
+
 pub(crate) fn init_sdl() -> Result<DesktopSdl> {
     // All desktop-output sessions (across restarts and channels) are routed
-    // through the single persistent thread in `sdl_thread`, so SDL and
-    // libdecor/GTK always see the same OS thread for their whole process
-    // lifetime. That thread affinity is what libdecor's GTK plugin needs;
-    // without it window creation can fail with "Failed to load plugin
-    // 'libdecor-gtk.so': failed to init".
+    // through the single persistent thread in `sdl_thread`, so SDL resources
+    // always live on one OS thread. Wayland windows are created borderless and
+    // get a small in-canvas titlebar instead of libdecor-provided decorations,
+    // which avoids libdecor/GTK initialization failures on non-main threads.
     //
     // By default SDL installs its own SIGINT/SIGTERM handlers and turns them
     // into an `Event::Quit`, which `handle_events` treats as "stop the current
@@ -681,6 +1522,7 @@ pub(crate) fn init_sdl() -> Result<DesktopSdl> {
     // restores the normal OS default (Ctrl-C terminates the process), matching
     // the behavior of the other output modes, which don't use SDL at all.
     sdl2::hint::set("SDL_NO_SIGNAL_HANDLERS", "1");
+    sdl2::hint::set("SDL_VIDEO_WAYLAND_ALLOW_LIBDECOR", "0");
     sdl2::hint::set("SDL_VIDEO_WAYLAND_PREFER_LIBDECOR", "0");
     let sdl = sdl2::init().map_err(anyhow::Error::msg)?;
     let video = sdl.video().map_err(anyhow::Error::msg)?;

--- a/backend/engine/src/output/desktop.rs
+++ b/backend/engine/src/output/desktop.rs
@@ -12,7 +12,7 @@ use std::{
 use anyhow::{Result, anyhow};
 use ffmpeg_next::{Rational, Rescale, frame};
 use sdl2::{
-    Sdl,
+    Sdl, VideoSubsystem,
     audio::{AudioQueue, AudioSpecDesired},
     event::Event,
     keyboard::Keycode,
@@ -80,6 +80,11 @@ pub(crate) struct DesktopFrameSender {
     audio_level_meter: AudioLevelMeter,
 }
 
+pub(crate) struct DesktopSdl {
+    sdl: Sdl,
+    video: VideoSubsystem,
+}
+
 struct DesktopRenderer {
     // Texture must be dropped before its parent canvas.
     texture: Texture,
@@ -108,9 +113,9 @@ struct DesktopRenderer {
 }
 
 impl DesktopOutput {
-    pub(super) fn open(cfg: &OutputConfig) -> Result<Self> {
+    pub(super) fn open(cfg: &OutputConfig, desktop_sdl: DesktopSdl) -> Result<Self> {
         Ok(Self {
-            renderer: DesktopRenderer::open(cfg)?,
+            renderer: DesktopRenderer::open(cfg, desktop_sdl)?,
             audio_effects: Arc::new(Mutex::new(AudioEffectChain::new(
                 cfg.audio_effects.clone(),
                 cfg.sample_rate,
@@ -240,30 +245,13 @@ impl FrameOutput for DesktopFrameSender {
 }
 
 impl DesktopRenderer {
-    fn open(cfg: &OutputConfig) -> Result<Self> {
-        // All desktop-output sessions (across restarts and channels) are
-        // routed through the single persistent thread in `sdl_thread`, so SDL
-        // and libdecor/GTK always see the same OS thread for their whole
-        // process lifetime. That thread affinity is what libdecor's GTK
-        // plugin needs; without it window creation can fail with
-        // "Failed to load plugin 'libdecor-gtk.so': failed to init".
-        //
-        // By default SDL installs its own SIGINT/SIGTERM handlers and turns
-        // them into an `Event::Quit`, which `handle_events` treats as "stop
-        // the current clip" (the same as closing the window or pressing
-        // Escape) rather than as a request to terminate the whole process.
-        // Since the channel supervisor automatically restarts a stopped
-        // channel, Ctrl-C would just restart playback instead of exiting the
-        // process. Disabling SDL's signal handlers restores the normal OS
-        // default (Ctrl-C terminates the process), matching the behavior of
-        // the other output modes, which don't use SDL at all.
-        sdl2::hint::set("SDL_NO_SIGNAL_HANDLERS", "1");
-        sdl2::hint::set("SDL_VIDEO_WAYLAND_PREFER_LIBDECOR", "0");
-        let sdl = sdl2::init().map_err(anyhow::Error::msg)?;
-        let video = sdl.video().map_err(anyhow::Error::msg)?;
+    fn open(cfg: &OutputConfig, desktop_sdl: DesktopSdl) -> Result<Self> {
+        let DesktopSdl { sdl, video } = desktop_sdl;
         let audio_subsystem = sdl.audio().map_err(anyhow::Error::msg)?;
+        let (window_width, window_height) =
+            cfg.desktop_window_size.unwrap_or((cfg.width, cfg.height));
         let window = video
-            .window("ffplayout", cfg.width, cfg.height)
+            .window("ffplayout", window_width, window_height)
             .position_centered()
             .resizable()
             .build()
@@ -674,6 +662,59 @@ impl DesktopRenderer {
             .map_err(anyhow::Error::msg)?;
         Ok(())
     }
+}
+
+pub(crate) fn init_sdl() -> Result<DesktopSdl> {
+    // All desktop-output sessions (across restarts and channels) are routed
+    // through the single persistent thread in `sdl_thread`, so SDL and
+    // libdecor/GTK always see the same OS thread for their whole process
+    // lifetime. That thread affinity is what libdecor's GTK plugin needs;
+    // without it window creation can fail with "Failed to load plugin
+    // 'libdecor-gtk.so': failed to init".
+    //
+    // By default SDL installs its own SIGINT/SIGTERM handlers and turns them
+    // into an `Event::Quit`, which `handle_events` treats as "stop the current
+    // clip" (the same as closing the window or pressing Escape) rather than as
+    // a request to terminate the whole process. Since the channel supervisor
+    // automatically restarts a stopped channel, Ctrl-C would just restart
+    // playback instead of exiting the process. Disabling SDL's signal handlers
+    // restores the normal OS default (Ctrl-C terminates the process), matching
+    // the behavior of the other output modes, which don't use SDL at all.
+    sdl2::hint::set("SDL_NO_SIGNAL_HANDLERS", "1");
+    sdl2::hint::set("SDL_VIDEO_WAYLAND_PREFER_LIBDECOR", "0");
+    let sdl = sdl2::init().map_err(anyhow::Error::msg)?;
+    let video = sdl.video().map_err(anyhow::Error::msg)?;
+    Ok(DesktopSdl { sdl, video })
+}
+
+pub(crate) fn config_for_primary_display(
+    mut config: OutputConfig,
+    desktop_sdl: &DesktopSdl,
+) -> OutputConfig {
+    let window_width = config.width;
+    let window_height = config.height;
+    if let Ok((display_width, display_height)) = primary_display_size(&desktop_sdl.video) {
+        config.width = display_width;
+        config.height = display_height;
+        config = config.with_desktop_window_size(window_width, window_height);
+    }
+    config
+}
+
+fn primary_display_size(video: &VideoSubsystem) -> Result<(u32, u32)> {
+    let mode = video.current_display_mode(0).map_err(anyhow::Error::msg)?;
+    if mode.w <= 0 || mode.h <= 0 {
+        return Err(anyhow!(
+            "SDL reported an invalid primary display size: {}x{}",
+            mode.w,
+            mode.h
+        ));
+    }
+    Ok((even_dimension(mode.w as u32), even_dimension(mode.h as u32)))
+}
+
+fn even_dimension(value: u32) -> u32 {
+    (value & !1).max(2)
 }
 
 struct AudioMasterClock {

--- a/backend/engine/src/output/desktop.rs
+++ b/backend/engine/src/output/desktop.rs
@@ -17,14 +17,15 @@ use sdl2::{
     event::Event,
     keyboard::Keycode,
     pixels::{Color, PixelFormatEnum},
+    rect::Rect,
     render::{Canvas, Texture},
-    video::Window,
+    video::{FullscreenType, Window},
 };
 
 use super::{FrameOutput, PlaybackStopped};
 use crate::{
     analysis::audio_level::{AudioLevelCallback, AudioLevelMeter},
-    audio_mixer::AudioEffectChain,
+    audio_mixer::{AudioEffectChain, AudioEffectsControl},
     utils::config::OutputConfig,
 };
 
@@ -37,6 +38,10 @@ const VIDEO_DROP_THRESHOLD_FRAMES: i64 = 3;
 const VIDEO_STARVATION_GRACE_FRAMES: i64 = 2;
 const SCHEDULER_INTERVAL: Duration = Duration::from_millis(2);
 const OUTPUT_CHANNEL_CAPACITY: usize = 64;
+const DESKTOP_VOLUME_STEP: f64 = 0.05;
+const DESKTOP_VOLUME_MIN: f64 = 0.0;
+const DESKTOP_VOLUME_MAX: f64 = 1.5;
+const VOLUME_OVERLAY_DURATION: Duration = Duration::from_millis(900);
 
 fn video_prebuffer_ready(queue_len: usize, video_finished: bool, force: bool) -> bool {
     force || video_finished || queue_len >= VIDEO_PREBUFFER_FRAMES
@@ -80,6 +85,7 @@ struct DesktopRenderer {
     texture: Texture,
     canvas: Canvas<Window>,
     audio: AudioQueue<f32>,
+    audio_effects_control: AudioEffectsControl,
     event_pump: sdl2::EventPump,
     video_queue: VecDeque<frame::Video>,
     pending_audio: VecDeque<(Vec<f32>, usize)>,
@@ -95,6 +101,8 @@ struct DesktopRenderer {
     last_rendered_video_pts: Option<i64>,
     last_video_present: Option<Instant>,
     last_starvation_report: Option<Instant>,
+    fullscreen: bool,
+    volume_overlay_until: Option<Instant>,
     // SDL context must outlive all resources above.
     _sdl: Sdl,
 }
@@ -156,10 +164,23 @@ impl DesktopOutput {
             .map_err(|error| anyhow!("failed to start decode worker: {error}"))?;
 
         let render_result = self.renderer.run_clip(receiver);
+        if let Err(error) = render_result {
+            if error.downcast_ref::<PlaybackStopped>().is_some() {
+                thread::spawn(move || {
+                    if worker.join().is_err() {
+                        log::warn!("decode worker panicked after desktop playback stopped");
+                    }
+                });
+                return Err(error);
+            }
+
+            let _ = worker.join();
+            return Err(error);
+        }
+
         let worker_result = worker
             .join()
             .map_err(|_| anyhow!("decode worker panicked"))?;
-        render_result?;
         Ok(worker_result)
     }
 
@@ -279,6 +300,7 @@ impl DesktopRenderer {
         Ok(Self {
             canvas,
             audio,
+            audio_effects_control: cfg.audio_effects.clone(),
             event_pump,
             video_queue: VecDeque::new(),
             pending_audio: VecDeque::new(),
@@ -294,6 +316,8 @@ impl DesktopRenderer {
             last_rendered_video_pts: None,
             last_video_present: None,
             last_starvation_report: None,
+            fullscreen: false,
+            volume_overlay_until: None,
             texture,
             _sdl: sdl,
         })
@@ -524,6 +548,7 @@ impl DesktopRenderer {
         self.canvas
             .copy(&self.texture, None, None)
             .map_err(anyhow::Error::msg)?;
+        self.draw_volume_overlay()?;
         self.canvas.present();
         Ok(())
     }
@@ -531,6 +556,7 @@ impl DesktopRenderer {
     fn render_black_frame(&mut self) {
         self.canvas.set_draw_color(Color::RGB(0, 0, 0));
         self.canvas.clear();
+        let _ = self.draw_volume_overlay();
         self.canvas.present();
     }
 
@@ -559,18 +585,93 @@ impl DesktopRenderer {
     }
 
     fn handle_events(&mut self) -> Result<()> {
-        if self.event_pump.poll_iter().any(|event| {
-            matches!(
-                event,
-                Event::Quit { .. }
-                    | Event::KeyDown {
-                        keycode: Some(Keycode::Escape),
-                        ..
-                    }
-            )
-        }) {
-            return Err(PlaybackStopped.into());
+        while let Some(event) = self.event_pump.poll_event() {
+            match event {
+                Event::Quit { .. } => return Err(PlaybackStopped.into()),
+                Event::KeyDown {
+                    keycode: Some(Keycode::F),
+                    repeat: false,
+                    ..
+                } => self.toggle_fullscreen()?,
+                Event::KeyDown {
+                    keycode: Some(Keycode::Left),
+                    ..
+                } => self.adjust_volume(-DESKTOP_VOLUME_STEP)?,
+                Event::KeyDown {
+                    keycode: Some(Keycode::Right),
+                    ..
+                } => self.adjust_volume(DESKTOP_VOLUME_STEP)?,
+                Event::KeyDown {
+                    keycode: Some(Keycode::Escape),
+                    ..
+                } => return Err(PlaybackStopped.into()),
+                _ => {}
+            }
         }
+        Ok(())
+    }
+
+    fn adjust_volume(&mut self, delta: f64) -> Result<()> {
+        let volume = adjusted_volume(self.audio_effects_control.volume(), delta);
+        self.audio_effects_control.set_volume(volume)?;
+        self.volume_overlay_until = Some(Instant::now() + VOLUME_OVERLAY_DURATION);
+        Ok(())
+    }
+
+    fn toggle_fullscreen(&mut self) -> Result<()> {
+        self.set_fullscreen(!self.fullscreen)
+    }
+
+    fn set_fullscreen(&mut self, fullscreen: bool) -> Result<()> {
+        let mode = if fullscreen {
+            FullscreenType::Desktop
+        } else {
+            FullscreenType::Off
+        };
+        self.canvas
+            .window_mut()
+            .set_fullscreen(mode)
+            .map_err(anyhow::Error::msg)?;
+        self.fullscreen = fullscreen;
+        Ok(())
+    }
+
+    fn draw_volume_overlay(&mut self) -> Result<()> {
+        if self
+            .volume_overlay_until
+            .is_none_or(|until| Instant::now() >= until)
+        {
+            self.volume_overlay_until = None;
+            return Ok(());
+        }
+
+        let (width, height) = self.canvas.output_size().map_err(anyhow::Error::msg)?;
+        let panel_width = (width / 3).clamp(180, 360);
+        let panel_height = 28;
+        let margin = 24;
+        let x = ((width - panel_width) / 2) as i32;
+        let y = height.saturating_sub(panel_height + margin) as i32;
+        let panel = Rect::new(x, y, panel_width, panel_height);
+        let track_margin = 8;
+        let track_height = 6;
+        let track_width = panel_width - track_margin * 2;
+        let track_x = x + track_margin as i32;
+        let track_y = y + ((panel_height - track_height) / 2) as i32;
+        let fill_width = ((self.audio_effects_control.volume() / DESKTOP_VOLUME_MAX)
+            .clamp(0.0, 1.0)
+            * f64::from(track_width))
+        .round() as u32;
+
+        self.canvas.set_draw_color(Color::RGB(16, 18, 20));
+        self.canvas.fill_rect(panel).map_err(anyhow::Error::msg)?;
+        self.canvas.set_draw_color(Color::RGB(78, 86, 96));
+        self.canvas
+            .fill_rect(Rect::new(track_x, track_y, track_width, track_height))
+            .map_err(anyhow::Error::msg)?;
+        self.canvas.set_draw_color(Color::RGB(238, 238, 238));
+        self.canvas
+            .fill_rect(Rect::new(track_x, track_y, fill_width, track_height))
+            .map_err(anyhow::Error::msg)?;
         Ok(())
     }
 }
@@ -620,6 +721,10 @@ fn video_pts_in_audio_samples(video_pts: i64, video_time_base: Rational, sample_
     video_pts
         .rescale(video_time_base, Rational(1, sample_rate as i32))
         .max(0) as u64
+}
+
+fn adjusted_volume(volume: f64, delta: f64) -> f64 {
+    (volume + delta).clamp(DESKTOP_VOLUME_MIN, DESKTOP_VOLUME_MAX)
 }
 
 #[cfg(test)]
@@ -688,5 +793,12 @@ mod tests {
         assert!(!video_frame_is_too_late(10, 13, 2));
         assert!(video_frame_is_too_late(10, 14, 2));
         assert!(!video_frame_is_too_late(10, 20, 1));
+    }
+
+    #[test]
+    fn desktop_volume_adjustment_is_clamped() {
+        assert_eq!(adjusted_volume(1.0, 0.05), 1.05);
+        assert_eq!(adjusted_volume(1.49, 0.05), DESKTOP_VOLUME_MAX);
+        assert_eq!(adjusted_volume(0.01, -0.05), DESKTOP_VOLUME_MIN);
     }
 }

--- a/backend/engine/src/output/mod.rs
+++ b/backend/engine/src/output/mod.rs
@@ -14,7 +14,7 @@ use anyhow::Result;
 #[cfg(feature = "desktop")]
 use anyhow::anyhow;
 #[cfg(feature = "desktop")]
-use desktop::{DesktopFrameSender, DesktopOutput};
+use desktop::{DesktopFrameSender, DesktopOutput, DesktopSdl};
 use encoded::{EncodedFormat, EncodedOutput};
 use ffmpeg_next::frame;
 
@@ -49,6 +49,19 @@ pub(crate) trait FrameOutput {
     ) -> Result<()> {
         Ok(())
     }
+}
+
+#[cfg(feature = "desktop")]
+pub(crate) fn init_desktop_sdl() -> Result<DesktopSdl> {
+    desktop::init_sdl()
+}
+
+#[cfg(feature = "desktop")]
+pub(crate) fn desktop_config_for_primary_display(
+    config: OutputConfig,
+    desktop_sdl: &DesktopSdl,
+) -> OutputConfig {
+    desktop::config_for_primary_display(config, desktop_sdl)
 }
 
 pub(crate) struct Output {
@@ -91,9 +104,9 @@ impl Output {
     }
 
     #[cfg(feature = "desktop")]
-    pub(crate) fn open_desktop(cfg: &OutputConfig) -> Result<Self> {
+    pub(crate) fn open_desktop(cfg: &OutputConfig, desktop_sdl: DesktopSdl) -> Result<Self> {
         Ok(Self {
-            kind: OutputKind::Desktop(DesktopOutput::open(cfg)?),
+            kind: OutputKind::Desktop(DesktopOutput::open(cfg, desktop_sdl)?),
         })
     }
 

--- a/backend/engine/src/output/mod.rs
+++ b/backend/engine/src/output/mod.rs
@@ -18,7 +18,10 @@ use desktop::{DesktopFrameSender, DesktopOutput, DesktopSdl};
 use encoded::{EncodedFormat, EncodedOutput};
 use ffmpeg_next::frame;
 
-use crate::utils::config::{HlsSubtitle, HlsVariant, OutputConfig};
+use crate::{
+    compositor::logo::{LogoOverlay, blend_logo},
+    utils::config::{HlsSubtitle, HlsVariant, OutputConfig},
+};
 
 #[derive(Debug)]
 pub(crate) struct PlaybackStopped;
@@ -35,6 +38,14 @@ pub(crate) trait FrameOutput {
     fn audio_frame_size(&self) -> usize;
     fn encode_video(&mut self, frame: &frame::Video) -> Result<()>;
     fn encode_audio(&mut self, frame: &frame::Audio) -> Result<()>;
+    fn apply_logo_overlay(
+        &mut self,
+        frame: &mut frame::Video,
+        logo: &LogoOverlay,
+        opacity_factor: f64,
+    ) {
+        blend_logo(frame, logo, opacity_factor);
+    }
     fn set_video_end(&mut self, _video_end_pts: Option<i64>) -> Result<()> {
         Ok(())
     }
@@ -69,15 +80,19 @@ pub(crate) struct Output {
 }
 
 enum OutputKind {
-    Encoded(EncodedOutput),
+    Encoded(Box<EncodedOutput>),
     #[cfg(feature = "desktop")]
-    Desktop(DesktopOutput),
+    Desktop(Box<DesktopOutput>),
 }
 
 impl Output {
     pub(crate) fn open(path: &str, cfg: &OutputConfig) -> Result<Self> {
         Ok(Self {
-            kind: OutputKind::Encoded(EncodedOutput::open(path, cfg, EncodedFormat::Auto)?),
+            kind: OutputKind::Encoded(Box::new(EncodedOutput::open(
+                path,
+                cfg,
+                EncodedFormat::Auto,
+            )?)),
         })
     }
 
@@ -90,7 +105,7 @@ impl Output {
         hls_list_size: u32,
     ) -> Result<Self> {
         Ok(Self {
-            kind: OutputKind::Encoded(EncodedOutput::open(
+            kind: OutputKind::Encoded(Box::new(EncodedOutput::open(
                 path,
                 cfg,
                 EncodedFormat::Hls {
@@ -99,14 +114,14 @@ impl Output {
                     segment_seconds: hls_segment_seconds,
                     list_size: hls_list_size,
                 },
-            )?),
+            )?)),
         })
     }
 
     #[cfg(feature = "desktop")]
     pub(crate) fn open_desktop(cfg: &OutputConfig, desktop_sdl: DesktopSdl) -> Result<Self> {
         Ok(Self {
-            kind: OutputKind::Desktop(DesktopOutput::open(cfg, desktop_sdl)?),
+            kind: OutputKind::Desktop(Box::new(DesktopOutput::open(cfg, desktop_sdl)?)),
         })
     }
 
@@ -171,6 +186,19 @@ impl FrameOutput for Output {
 
     fn encode_audio(&mut self, frame: &frame::Audio) -> Result<()> {
         Self::encode_audio(self, frame)
+    }
+
+    fn apply_logo_overlay(
+        &mut self,
+        frame: &mut frame::Video,
+        logo: &LogoOverlay,
+        opacity_factor: f64,
+    ) {
+        match &mut self.kind {
+            OutputKind::Encoded(_) => blend_logo(frame, logo, opacity_factor),
+            #[cfg(feature = "desktop")]
+            OutputKind::Desktop(_) => {}
+        }
     }
 
     fn write_vtt_subtitles(

--- a/backend/engine/src/playout.rs
+++ b/backend/engine/src/playout.rs
@@ -532,7 +532,7 @@ fn repeat_single_video_frame_to_limit<O: FrameOutput>(
             return Err(PlaybackSkipped.into());
         }
         let mut frame = frame.clone();
-        apply_overlays(&mut frame, video, timeline, logo_fade_plan);
+        apply_overlays(&mut frame, video, timeline, logo_fade_plan, output);
         frame.set_pts(Some(timeline.video_pts));
         output.encode_video(&frame)?;
         video.last_composited_frame = Some(frame);
@@ -648,7 +648,7 @@ fn receive_video_frames<O: FrameOutput>(
             // positions) on top of each other for duplicated frames during
             // frame-rate up-conversion.
             let mut frame = pristine.clone();
-            apply_overlays(&mut frame, video, timeline, logo_fade_plan);
+            apply_overlays(&mut frame, video, timeline, logo_fade_plan, output);
             frame.set_pts(Some(timeline.video_pts));
             output.encode_video(&frame)?;
             video.last_composited_frame = Some(frame);
@@ -664,12 +664,13 @@ fn apply_overlays(
     video: &mut VideoDecoder,
     timeline: &mut Timeline,
     logo_fade_plan: LogoFadePlan,
+    output: &mut impl FrameOutput,
 ) {
     let opacity = logo_fade_plan.opacity_at(timeline.video_pts, timeline.logo_opacity);
     timeline.logo_opacity = opacity;
 
     if let Some(logo) = &video.logo {
-        blend_logo(frame, logo, opacity);
+        output.apply_logo_overlay(frame, logo, opacity);
     }
     if let Some(text) = &mut video.text {
         text.blend(frame, timeline.video_pts, timeline.text_pts);

--- a/backend/engine/src/utils/config.rs
+++ b/backend/engine/src/utils/config.rs
@@ -436,6 +436,7 @@ impl OutputConfig {
         self
     }
 
+    #[cfg(feature = "desktop")]
     pub(crate) fn with_desktop_window_size(mut self, width: u32, height: u32) -> Self {
         self.desktop_window_size = Some((width, height));
         self

--- a/backend/engine/src/utils/config.rs
+++ b/backend/engine/src/utils/config.rs
@@ -166,6 +166,7 @@ mod log_level_tests {
 pub struct OutputConfig {
     pub width: u32,
     pub height: u32,
+    pub desktop_window_size: Option<(u32, u32)>,
     pub fps: u32,
     pub sample_rate: u32,
     pub video_time_base: Rational,
@@ -396,6 +397,7 @@ impl OutputConfig {
         Self {
             width,
             height,
+            desktop_window_size: None,
             fps,
             sample_rate,
             video_time_base: Rational(1, fps as i32),
@@ -429,6 +431,11 @@ impl OutputConfig {
 
     pub fn with_audio_level_callback(mut self, callback: Option<AudioLevelCallback>) -> Self {
         self.audio_level_callback = callback;
+        self
+    }
+
+    pub(crate) fn with_desktop_window_size(mut self, width: u32, height: u32) -> Self {
+        self.desktop_window_size = Some((width, height));
         self
     }
 

--- a/backend/engine/src/utils/config.rs
+++ b/backend/engine/src/utils/config.rs
@@ -167,6 +167,7 @@ pub struct OutputConfig {
     pub width: u32,
     pub height: u32,
     pub desktop_window_size: Option<(u32, u32)>,
+    pub desktop_fullscreen: bool,
     pub fps: u32,
     pub sample_rate: u32,
     pub video_time_base: Rational,
@@ -398,6 +399,7 @@ impl OutputConfig {
             width,
             height,
             desktop_window_size: None,
+            desktop_fullscreen: false,
             fps,
             sample_rate,
             video_time_base: Rational(1, fps as i32),
@@ -436,6 +438,11 @@ impl OutputConfig {
 
     pub(crate) fn with_desktop_window_size(mut self, width: u32, height: u32) -> Self {
         self.desktop_window_size = Some((width, height));
+        self
+    }
+
+    pub fn with_desktop_fullscreen(mut self, fullscreen: bool) -> Self {
+        self.desktop_fullscreen = fullscreen;
         self
     }
 

--- a/backend/engine/src/utils/logging.rs
+++ b/backend/engine/src/utils/logging.rs
@@ -54,7 +54,9 @@ static USER_SKIPPED_FFMPEG_LOG_LINES: Mutex<Vec<String>> = Mutex::new(Vec::new()
 type FfmpegVaList = *mut ffi::__va_list_tag;
 #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
 type FfmpegVaList = ffi::va_list;
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+type FfmpegVaList = *mut ffi::__va_list_tag;
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 type FfmpegVaList = ffi::va_list;
 
 pub(crate) fn init(

--- a/backend/engine/src/utils/logging.rs
+++ b/backend/engine/src/utils/logging.rs
@@ -50,8 +50,10 @@ static LOG_DEDUP: Mutex<LogDedup> = Mutex::new(LogDedup::new());
 static SKIPPED_FFMPEG_LOG_PATTERNS: OnceLock<Vec<Regex>> = OnceLock::new();
 static USER_SKIPPED_FFMPEG_LOG_LINES: Mutex<Vec<String>> = Mutex::new(Vec::new());
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 type FfmpegVaList = *mut ffi::__va_list_tag;
+#[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+type FfmpegVaList = ffi::va_list;
 #[cfg(target_os = "macos")]
 type FfmpegVaList = ffi::va_list;
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN [[ -f "/tmp/ffplayout-v${FFPLAYOUT_VERSION}_x86_64-unknown-linux-musl.tar.gz
     tar xf "ffplayout-v${FFPLAYOUT_VERSION}_x86_64-unknown-linux-musl.tar.gz" && \
     cp ffplayout /usr/bin/ && \
     mkdir -p /usr/share/ffplayout/ && \
-    cp assets/dummy.vtt assets/logo.png assets/DejaVuSans.ttf assets/FONT_LICENSE.txt /usr/share/ffplayout/ && \
+    cp assets/dummy.vtt assets/logo.png /usr/share/ffplayout/ && \
     rm -rf /tmp/* && \
     mkdir ${DB}
 

--- a/docker/nonfree.Dockerfile
+++ b/docker/nonfree.Dockerfile
@@ -29,7 +29,7 @@ RUN [[ -f "/tmp/ffplayout-v${FFPLAYOUT_VERSION}_x86_64-unknown-linux-musl.tar.gz
     tar xf "ffplayout-v${FFPLAYOUT_VERSION}_x86_64-unknown-linux-musl.tar.gz" && \
     cp ffplayout /usr/bin/ && \
     mkdir -p /usr/share/ffplayout/ && \
-    cp assets/dummy.vtt assets/logo.png assets/DejaVuSans.ttf assets/FONT_LICENSE.txt /usr/share/ffplayout/ && \
+    cp assets/dummy.vtt assets/logo.png /usr/share/ffplayout/ && \
     rm -rf /tmp/* && \
     mkdir ${DB}
 

--- a/docker/nvidia.Dockerfile
+++ b/docker/nvidia.Dockerfile
@@ -215,7 +215,7 @@ RUN cd /tmp && \
     tar xf "ffplayout-v${FFPLAYOUT_VERSION}_x86_64-unknown-linux-musl.tar.gz" && \
     cp ffplayout /usr/bin/ && \
     mkdir -p /usr/share/ffplayout/ && \
-    cp assets/dummy.vtt assets/logo.png assets/DejaVuSans.ttf assets/FONT_LICENSE.txt /usr/share/ffplayout/ && \
+    cp assets/dummy.vtt assets/logo.png /usr/share/ffplayout/ && \
     rm -rf /tmp/* && \
     mkdir ${DB}
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,6 +24,6 @@ ffplayout provides ***.deb** and ***.rpm** packages, which makes it easier to in
 - Give ownership of `/etc/ffplayout` and `/var/log/ffplayout` to **ffpu**
 - Copy **assets/ffplayout.service** to `/etc/systemd/system`
 - Copy **assets/ffplayout.1.gz** to `/usr/share/man/man1/`
-- Copy **assets/dummy.vtt**, **assets/logo.png**, **assets/DejaVuSans.ttf**, and **assets/FONT_LICENSE.txt** to `/usr/share/ffplayout/`
+- Copy **assets/dummy.vtt**, **assets/logo.png** to `/usr/share/ffplayout/`
 - Activate the service and run it: `systemctl enable --now ffplayout`
 - Initialize the defaults and add a global admin user: `sudo -u ffpu ffplayout -i`

--- a/frontend/src/components/config/ConfigPlayout.vue
+++ b/frontend/src/components/config/ConfigPlayout.vue
@@ -50,6 +50,7 @@ const output = computed({
         configStore.playout.output.hls_playlist_name = output?.hls_playlist_name ?? 'stream'
         configStore.playout.output.hls_segment_duration = output?.hls_segment_duration ?? 6
         configStore.playout.output.hls_list_size = output?.hls_list_size ?? 600
+        configStore.playout.output.desktop_fullscreen = output?.desktop_fullscreen ?? false
         configStore.playout.output.width = output?.width ?? 1280
         configStore.playout.output.height = output?.height ?? 720
         configStore.playout.output.fps = output?.fps ?? 25
@@ -547,6 +548,16 @@ async function onSubmitPlayout() {
                         type="url"
                         class="input input-sm w-full max-w-lg"
                     />
+                </fieldset>
+                <fieldset v-if="output === 'desktop'" class="fieldset mt-2 rounded-box w-full">
+                    <label class="fieldset-label text-base-content">
+                        <input
+                            v-model="configStore.playout.output.desktop_fullscreen"
+                            type="checkbox"
+                            class="checkbox"
+                        />
+                        Start Fullscreen
+                    </label>
                 </fieldset>
 
                 <fieldset class="fieldset">

--- a/frontend/src/locales/de-DE.ts
+++ b/frontend/src/locales/de-DE.ts
@@ -190,7 +190,7 @@ export default {
         logIgnore: 'Ignoriere Zeichenfolgen, die übereinstimmende Zeilen enthalten; das Format ist eine durch Semikolon getrennte Liste.',
         processingHelp: 'Die Standardverarbeitung für alle Clips stellt die Einzigartigkeit sicher.',
         processingLogoPath: 'Das Logo wird nur verwendet, wenn der Pfad existiert; der Pfad ist relativ zum Speicherordner.',
-        processingLogoScale: `Lass die Skalierung des Logos leer, wenn keine Skalierung erforderlich ist. Das Format lautet 'Breite:Höhe', zum Beispiel: '100:-1' für proportionale Skalierung.`,
+        processingLogoScale: `Lass die Skalierung des Logos leer, wenn keine Skalierung erforderlich ist. Das Format lautet 'Breite:Höhe', zum Beispiel: '100:-1' oder '12%:-1' für proportionale Skalierung.`,
         processingLogoPosition: `Die Position wird im Format 'x:y' angegeben.`,
         processingAudioTracks: 'Gib an, wie viele Audiospuren verarbeitet werden sollen.',
         processingAudioIndex: 'Welche Audiospur verwendet werden soll, -1 für alle.',

--- a/frontend/src/locales/en-US.ts
+++ b/frontend/src/locales/en-US.ts
@@ -190,7 +190,7 @@ export default {
         logIgnore: 'Ignore strings that contain matched lines; the format is a semicolon-separated list.',
         processingHelp: 'Default processing for all clips ensures uniqueness.',
         processingLogoPath: 'The logo is used only if the path exists; the path is relative to the storage folder.',
-        processingLogoScale: `Leave logo scale blank if no scaling is needed. The format is 'width:height', for example: '100:-1' for proportional scaling.`,
+        processingLogoScale: `Leave logo scale blank if no scaling is needed. The format is 'width:height', for example: '100:-1' or '12%:-1' for proportional scaling.`,
         processingLogoPosition: `Position is specified in the format 'x:y'`,
         processingAudioTracks: 'Specify how many audio tracks should be processed.',
         processingAudioIndex: 'Which audio line to use, -1 for all.',

--- a/frontend/src/locales/pt-BR.ts
+++ b/frontend/src/locales/pt-BR.ts
@@ -190,7 +190,7 @@ export default {
         logIgnore: 'Ignorar strings que contenham linhas correspondentes; o formato é uma lista separada por ponto e vírgula.',
         processingHelp: 'O processamento padrão para todos os clipes garante a exclusividade.',
         processingLogoPath: 'O logotipo só é usado se o caminho existir; o caminho é relativo à pasta de armazenamento.',
-        processingLogoScale: `Deixe a escala do logotipo em branco se não for necessário escalonamento. O formato é 'largura:altura', por exemplo: '100:-1' para escalonamento proporcional.`,
+        processingLogoScale: `Deixe a escala do logotipo em branco se não for necessário escalonamento. O formato é 'largura:altura', por exemplo: '100:-1' ou '12%:-1' para escalonamento proporcional.`,
         processingLogoPosition: `A posição é especificada no formato 'x:y'.`,
         processingAudioTracks: 'Especifique quantas faixas de áudio devem ser processadas.',
         processingAudioIndex: 'Qual linha de áudio usar, -1 para todas.',

--- a/frontend/src/locales/ru-RU.ts
+++ b/frontend/src/locales/ru-RU.ts
@@ -194,7 +194,7 @@ export default {
         logIgnore: 'Ignore strings that contain matched lines; the format is a semicolon-separated list.',
         processingHelp: 'Default processing for all clips ensures uniqueness.',
         processingLogoPath: 'The logo is used only if the path exists; the path is relative to the storage folder.',
-        processingLogoScale: `Leave logo scale blank if no scaling is needed. The format is 'width:height', for example: '100:-1' for proportional scaling.`,
+        processingLogoScale: `Leave logo scale blank if no scaling is needed. The format is 'width:height', for example: '100:-1' or '12%:-1' for proportional scaling.`,
         processingLogoPosition: `Position is specified in the format 'x:y'`,
         processingAudioTracks: 'Specify how many audio tracks should be processed.',
         processingAudioIndex: 'Which audio line to use, -1 for all.',

--- a/frontend/src/types/index.d.ts
+++ b/frontend/src/types/index.d.ts
@@ -27,6 +27,7 @@ declare global {
         hls_playlist_name: string | null
         hls_segment_duration: number | null
         hls_list_size: number | null
+        desktop_fullscreen: boolean
         width: number
         height: number
         fps: number

--- a/frontend/src/types/playout_config.d.ts
+++ b/frontend/src/types/playout_config.d.ts
@@ -8,7 +8,7 @@ export type Logging = { ffmpeg_level: string, ingest_level: string, detect_silen
 
 export type Mail = { show: boolean, subject: string, recipient: string, mail_level: string, interval: bigint, };
 
-export type Output = { id: number, mode: OutputMode, stream_url: string, hls_playlist_name: string, hls_segment_duration: number, hls_list_size: number, width: number, height: number, fps: number, video_preset: string, rate_control: string, video_quality: number, video_maxrate: number, audio_bitrate: number, 
+export type Output = { id: number, mode: OutputMode, stream_url: string, hls_playlist_name: string, hls_segment_duration: number, hls_list_size: number, desktop_fullscreen: boolean, width: number, height: number, fps: number, video_preset: string, rate_control: string, video_quality: number, video_maxrate: number, audio_bitrate: number, 
 /**
  * Adaptive HLS renditions, one per entry, each formatted as
  * `NAME:WIDTHxHEIGHT:VIDEO_BITRATE[:AUDIO_BITRATE]` (e.g.

--- a/migrations/00001_create_tables.sql
+++ b/migrations/00001_create_tables.sql
@@ -88,6 +88,7 @@ CREATE TABLE IF NOT EXISTS outputs (
     hls_playlist_name TEXT,
     hls_segment_duration INTEGER,
     hls_list_size INTEGER,
+    desktop_fullscreen INTEGER NOT NULL DEFAULT 0,
     width INTEGER NOT NULL DEFAULT 1280,
     height INTEGER NOT NULL DEFAULT 720,
     fps REAL NOT NULL DEFAULT 25.0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.0.0-beta2",
+  "version": "2.0.0-beta3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.0.0-beta2",
+      "version": "2.0.0-beta3",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.2",
         "@unhead/vue": "^3.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,19 +29,19 @@
       },
       "devDependencies": {
         "@tsconfig/node22": "^22.0.5",
-        "@types/node": "^26.1.0",
+        "@types/node": "^26.1.1",
         "@vitejs/plugin-vue": "^6.0.7",
         "@vue/eslint-config-typescript": "^14.9.0",
         "@vue/tsconfig": "^0.9.1",
-        "daisyui": "^5.6.14",
+        "daisyui": "^5.6.16",
         "eslint": "^10.6.0",
         "eslint-plugin-vue": "~10.9.2",
         "jiti": "^2.7.0",
         "npm-run-all2": "^9.0.2",
         "typescript": "~6.0.3",
-        "vite": "^8.1.3",
+        "vite": "^8.1.4",
         "vite-plugin-vue-devtools": "^8.1.5",
-        "vue-tsc": "^3.3.6"
+        "vue-tsc": "^3.3.7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1772,9 +1772,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
-      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
       "cpu": [
         "arm64"
       ],
@@ -1788,9 +1788,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
-      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
       "cpu": [
         "arm64"
       ],
@@ -1804,9 +1804,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
-      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
       "cpu": [
         "x64"
       ],
@@ -1820,9 +1820,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
-      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
       "cpu": [
         "x64"
       ],
@@ -1836,9 +1836,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
-      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
       "cpu": [
         "arm"
       ],
@@ -1852,9 +1852,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
-      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1871,9 +1871,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
-      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
       ],
@@ -1890,9 +1890,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
-      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
       "cpu": [
         "ppc64"
       ],
@@ -1909,9 +1909,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
-      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
       ],
@@ -1928,9 +1928,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
-      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
       "cpu": [
         "x64"
       ],
@@ -1947,9 +1947,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
-      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
       ],
@@ -1966,9 +1966,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
-      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
       "cpu": [
         "arm64"
       ],
@@ -1982,9 +1982,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
-      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
       "cpu": [
         "wasm32"
       ],
@@ -2000,9 +2000,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
-      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
       "cpu": [
         "arm64"
       ],
@@ -2016,9 +2016,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
-      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
       "cpu": [
         "x64"
       ],
@@ -2351,9 +2351,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -3070,16 +3070,16 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.6.tgz",
-      "integrity": "sha512-LgBMZAy2sR3cQWknpyaxnI6yBkqDfLBPkbdhwRhQCvzfNJRQXPilgQIrdI/v4ytJ0sAq9bWhaPsjqBqneomJ3Q==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.7.tgz",
+      "integrity": "sha512-LzmkKinXAMMoh8Jfi/jMUSDUjuPdv8mynH5WJGKfXyZtDw3hQ6GBaoI6Bcnl/Xqlu32q/0Z6i/trp4VXykzyLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.28",
         "@vue/compiler-dom": "^3.5.0",
         "@vue/shared": "^3.5.0",
-        "alien-signals": "^3.2.0",
+        "alien-signals": "^3.2.1",
         "muggle-string": "^0.4.1",
         "path-browserify": "^1.0.1",
         "picomatch": "^4.0.4"
@@ -3591,9 +3591,9 @@
       "license": "MIT"
     },
     "node_modules/daisyui": {
-      "version": "5.6.14",
-      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.6.14.tgz",
-      "integrity": "sha512-PFDSzWbCSok8jNFprlJh3qzat1HeigsX8RKChHrjY8UFBB79idGP17Gtmcv5CaH4EyyhvIn8DDtua4sk6dRzOQ==",
+      "version": "5.6.16",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.6.16.tgz",
+      "integrity": "sha512-A5/IrcFCXyfzQ7M2fnKVPfMbKCVu0xeM7/G22gK1XRcp2dgA39kvFOeEAK8f2KpJJQJ+s9Jc5pZoJoYsPEJ8JQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4158,9 +4158,9 @@
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.388",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.388.tgz",
-      "integrity": "sha512-Pl/aJaqOOxYxda3vcx1IKSJimwYXHDkEnGn0F+kG2EE68dDtx2uCinaS+Vih8Z91B9t8CSAbiF/HKyWcnXjhzw==",
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
       "dev": true,
       "license": "ISC"
     },
@@ -5458,9 +5458,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6002,12 +6002,12 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
-      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.138.0",
+        "@oxc-project/types": "=0.139.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -6017,27 +6017,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.4",
-        "@rolldown/binding-darwin-arm64": "1.1.4",
-        "@rolldown/binding-darwin-x64": "1.1.4",
-        "@rolldown/binding-freebsd-x64": "1.1.4",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
-        "@rolldown/binding-linux-arm64-musl": "1.1.4",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
-        "@rolldown/binding-linux-x64-gnu": "1.1.4",
-        "@rolldown/binding-linux-x64-musl": "1.1.4",
-        "@rolldown/binding-openharmony-arm64": "1.1.4",
-        "@rolldown/binding-wasm32-wasi": "1.1.4",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
-        "@rolldown/binding-win32-x64-msvc": "1.1.4"
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/rolldown/node_modules/@oxc-project/types": {
-      "version": "0.138.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
-      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -6631,15 +6631,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
-      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
+        "picomatch": "^4.0.5",
         "postcss": "^8.5.16",
-        "rolldown": "~1.1.3",
+        "rolldown": "~1.1.4",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -7028,21 +7028,21 @@
       }
     },
     "node_modules/vue-router/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-      "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
       "license": "MIT",
       "engines": {
         "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/vue-router/node_modules/@babel/parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
-      "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^8.0.0"
+        "@babel/types": "^8.0.4"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -7052,13 +7052,13 @@
       }
     },
     "node_modules/vue-router/node_modules/@babel/types": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-      "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^8.0.0",
-        "@babel/helper-validator-identifier": "^8.0.0"
+        "@babel/helper-validator-identifier": "^8.0.4"
       },
       "engines": {
         "node": "^22.18.0 || >=24.11.0"
@@ -7119,14 +7119,14 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.6.tgz",
-      "integrity": "sha512-ERXGgbKSBGFUkavrJ1Iwj0ZVxKqB/5UOx65IXy7fPf2UsoI21n3ssQLwdvx8xyUGgJe9PvSZTM/FYzIdwUDPFA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.7.tgz",
+      "integrity": "sha512-+C+rgD49wAQ5bUTl2sp5a8Bzg4YoldMNXM+g7CFe604MYcQ8PrZPMQhIjJSzKXtPBCa+C5ayMipqjbA7splekQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "2.4.28",
-        "@vue/language-core": "3.3.6"
+        "@vue/language-core": "3.3.7"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"

--- a/package.json
+++ b/package.json
@@ -34,18 +34,18 @@
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.5",
-    "@types/node": "^26.1.0",
+    "@types/node": "^26.1.1",
     "@vitejs/plugin-vue": "^6.0.7",
     "@vue/eslint-config-typescript": "^14.9.0",
     "@vue/tsconfig": "^0.9.1",
-    "daisyui": "^5.6.14",
+    "daisyui": "^5.6.16",
     "eslint": "^10.6.0",
     "eslint-plugin-vue": "~10.9.2",
     "jiti": "^2.7.0",
     "npm-run-all2": "^9.0.2",
     "typescript": "~6.0.3",
-    "vite": "^8.1.3",
+    "vite": "^8.1.4",
     "vite-plugin-vue-devtools": "^8.1.5",
-    "vue-tsc": "^3.3.6"
+    "vue-tsc": "^3.3.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.0.0-beta2",
+  "version": "2.0.0-beta3",
   "description": "Web UI for ffplayout",
   "private": true,
   "type": "module",


### PR DESCRIPTION
- add desktop fullscreen startup option to output config
- render desktop logo as a separate SDL overlay instead of scaling with video frames
- support percentage-based logo scale values such as 12%:-1
- add borderless desktop titlebar controls, resize hit testing, and aspect-correct resize settling
- render desktop subtitles via cosmic-text with toggle support
- keep desktop-specific overlay behavior separate from encoded outputs
