### PR TITLE
security(settings): restrict filesystem paths to initial setup

### DIFF
--- a/backend/app/src/api/routes/global.rs
+++ b/backend/app/src/api/routes/global.rs
@@ -16,11 +16,6 @@ use crate::{
 
 #[derive(Debug, Serialize)]
 pub struct GlobalSettingsResponse {
-    logs: String,
-    playlists: String,
-    public: String,
-    storage: String,
-    shared: bool,
     smtp_server: String,
     smtp_user: String,
     smtp_password_set: bool,
@@ -31,11 +26,6 @@ pub struct GlobalSettingsResponse {
 impl From<GlobalSettings> for GlobalSettingsResponse {
     fn from(settings: GlobalSettings) -> Self {
         Self {
-            logs: settings.logs,
-            playlists: settings.playlists,
-            public: settings.public,
-            storage: settings.storage,
-            shared: settings.shared,
             smtp_server: settings.smtp_server,
             smtp_user: settings.smtp_user,
             smtp_password_set: !settings.smtp_password.is_empty(),
@@ -46,12 +36,8 @@ impl From<GlobalSettings> for GlobalSettingsResponse {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct UpdateGlobalSettings {
-    logs: String,
-    playlists: String,
-    public: String,
-    storage: String,
-    shared: bool,
     smtp_server: String,
     smtp_user: String,
     #[serde(default)]
@@ -79,11 +65,6 @@ pub async fn update_global(
     ensure_any_authority(&details, &[&Role::GlobalAdmin])?;
 
     let mut settings = handles::select_global(&state.pool).await?;
-    settings.logs = data.logs;
-    settings.playlists = data.playlists;
-    settings.public = data.public;
-    settings.storage = data.storage;
-    settings.shared = data.shared;
     settings.smtp_server = data.smtp_server;
     settings.smtp_user = data.smtp_user;
     settings.smtp_starttls = data.smtp_starttls;
@@ -93,7 +74,7 @@ pub async fn update_global(
         settings.smtp_password = password;
     }
 
-    handles::update_global(&state.pool, settings.clone()).await?;
+    handles::update_global_runtime_settings(&state.pool, settings.clone()).await?;
 
     Ok(Json(settings.into()))
 }
@@ -101,6 +82,7 @@ pub async fn update_global(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn global_settings_response_excludes_secrets() {
@@ -114,6 +96,24 @@ mod tests {
 
         assert!(value.get("secret").is_none());
         assert!(value.get("smtp_password").is_none());
+        assert!(value.get("logs").is_none());
+        assert!(value.get("playlists").is_none());
+        assert!(value.get("public").is_none());
+        assert!(value.get("storage").is_none());
+        assert!(value.get("shared").is_none());
         assert_eq!(value["smtp_password_set"], true);
+    }
+
+    #[test]
+    fn global_settings_update_rejects_path_fields() {
+        let request = json!({
+            "logs": "/tmp/ffplayout",
+            "smtp_server": "mail.example.org",
+            "smtp_user": "ffplayout@example.org",
+            "smtp_starttls": false,
+            "smtp_port": 465,
+        });
+
+        assert!(serde_json::from_value::<UpdateGlobalSettings>(request).is_err());
     }
 }

--- a/backend/app/src/api/routes/setup.rs
+++ b/backend/app/src/api/routes/setup.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use argon2::{
     Argon2, PasswordHasher,
@@ -62,6 +62,61 @@ pub struct SetupRequest {
     two_factor: bool,
 }
 
+const PROTECTED_SYSTEM_PATHS: &[&str] = &[
+    "/bin", "/boot", "/dev", "/etc", "/lib", "/lib64", "/proc", "/root", "/run", "/sbin", "/sys",
+    "/tmp", "/usr", "/var",
+];
+const APPLICATION_SYSTEM_PATHS: &[&str] = &[
+    "/usr/share/ffplayout",
+    "/var/lib/ffplayout",
+    "/var/log/ffplayout",
+];
+
+fn validate_setup_paths(settings: &SetupSettings) -> Result<(), ServiceError> {
+    [
+        ("Logging", settings.logs.as_str()),
+        ("Playlist", settings.playlists.as_str()),
+        ("Public", settings.public.as_str()),
+        ("Storage", settings.storage.as_str()),
+    ]
+    .into_iter()
+    .try_for_each(|(name, path)| validate_setup_path(name, path))
+}
+
+fn validate_setup_path(name: &str, value: &str) -> Result<(), ServiceError> {
+    let path = Path::new(value.trim());
+    if value.trim().is_empty() || path == Path::new("/") || !path.is_absolute() {
+        return Err(ServiceError::BadRequest(format!(
+            "{name} path must be an absolute directory"
+        )));
+    }
+
+    if path.components().any(|component| {
+        matches!(
+            component,
+            Component::CurDir | Component::ParentDir | Component::Prefix(_)
+        )
+    }) {
+        return Err(ServiceError::BadRequest(format!(
+            "{name} path must not contain relative components"
+        )));
+    }
+
+    let is_application_path = APPLICATION_SYSTEM_PATHS
+        .iter()
+        .any(|allowed| path.starts_with(allowed));
+    let is_protected_system_path = PROTECTED_SYSTEM_PATHS
+        .iter()
+        .any(|protected| path.starts_with(protected));
+    if is_protected_system_path && !is_application_path {
+        return Err(ServiceError::BadRequest(format!(
+            "{name} path must not point to a system directory"
+        )));
+    }
+
+    Ok(())
+}
+
 pub async fn get_setup_status(
     State(state): State<AppState>,
 ) -> Result<Json<SetupStatus>, ServiceError> {
@@ -87,6 +142,7 @@ pub async fn complete_setup(
             "Username, email, and password are required".to_string(),
         ));
     }
+    validate_setup_paths(&data.settings)?;
 
     let password = data.password;
     let password_hash = task::spawn_blocking(move || {
@@ -194,4 +250,42 @@ pub async fn complete_setup(
     .await?;
 
     Ok("Setup completed")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SetupSettings, validate_setup_paths};
+
+    fn settings(storage: &str) -> SetupSettings {
+        SetupSettings {
+            logs: "/var/log/ffplayout".to_string(),
+            playlists: "/var/lib/ffplayout/playlists".to_string(),
+            public: "/usr/share/ffplayout/public".to_string(),
+            storage: storage.to_string(),
+            shared: false,
+            smtp_server: String::new(),
+            smtp_user: String::new(),
+            smtp_password: String::new(),
+            smtp_starttls: false,
+            smtp_port: 465,
+        }
+    }
+
+    #[test]
+    fn setup_paths_allow_application_directories_and_custom_data_roots() {
+        assert!(validate_setup_paths(&settings("/mnt/media")).is_ok());
+    }
+
+    #[test]
+    fn setup_paths_reject_protected_system_directories() {
+        assert!(validate_setup_paths(&settings("/etc/ffplayout")).is_err());
+        assert!(validate_setup_paths(&settings("/var/lib")).is_err());
+    }
+
+    #[test]
+    fn setup_paths_reject_relative_components() {
+        assert!(validate_setup_paths(&settings("/mnt/../etc")).is_err());
+        assert!(validate_setup_paths(&settings("media")).is_err());
+        assert!(validate_setup_paths(&settings("/")).is_err());
+    }
 }

--- a/backend/app/src/db/handles/global.rs
+++ b/backend/app/src/db/handles/global.rs
@@ -35,6 +35,27 @@ pub async fn update_global(
     Ok(result)
 }
 
+/// Updates settings that are safe to change from the authenticated web UI.
+/// Filesystem paths remain local, setup-time configuration managed by `-i`.
+pub async fn update_global_runtime_settings(
+    pool: &SqlitePool,
+    global: GlobalSettings,
+) -> Result<SqliteQueryResult, ProcessError> {
+    const QUERY: &str = "UPDATE global SET smtp_server = $1, smtp_user = $2, smtp_password = $3,
+            smtp_starttls = $4, smtp_port = $5 WHERE id = 1";
+
+    let result = sqlx::query(QUERY)
+        .bind(global.smtp_server)
+        .bind(global.smtp_user)
+        .bind(global.smtp_password)
+        .bind(global.smtp_starttls)
+        .bind(global.smtp_port)
+        .execute(pool)
+        .await?;
+
+    Ok(result)
+}
+
 pub async fn mark_setup_completed(pool: &SqlitePool) -> Result<SqliteQueryResult, ProcessError> {
     const QUERY: &str = "UPDATE global SET setup_completed = 1 WHERE id = 1";
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -28,7 +28,7 @@ These endpoints do not use a bearer token.
 | `POST` | `/auth/refresh` | `{ "refresh": "..." }`. Rotates it and returns a new `{ "access": "...", "refresh": "..." }` pair. |
 | `POST` | `/auth/logout` | `{ "refresh": "..." }`. Revokes the complete refresh-token family for the session. |
 | `GET` | `/api/setup` | Reports whether first-time setup is required. |
-| `POST` | `/api/setup` | Completes first-time setup. It works only while no user exists. |
+| `POST` | `/api/setup` | Completes first-time setup. It works only while no user exists; directory paths must be absolute and cannot be protected system paths. |
 
 Access tokens are valid for 45 minutes and refresh tokens for 14 days. Refresh
 tokens are single-use: each successful refresh replaces the submitted token.
@@ -57,6 +57,8 @@ curl -X POST http://127.0.0.1:8787/api/setup \
 ```
 
 The JWT `secret` is neither exposed nor accepted by the API.
+Directory paths are accepted only by this first-time setup endpoint. Change
+them later locally with `ffplayout -i`.
 
 ## Roles
 
@@ -79,8 +81,8 @@ listed authenticated endpoints also enforce the channel assignment where an
 | `POST` | `/api/channel` | `GA` | Create a channel. |
 | `DELETE` | `/api/channel/{id}` | `GA` | Delete a channel. |
 | `GET` | `/api/channels` | `GA, CA, U` | List channels available to the current user. |
-| `GET` | `/api/global` | `GA` | Read global settings. The SMTP password is represented only by `smtp_password_set`. |
-| `PUT` | `/api/global` | `GA` | Update global settings. Omit `smtp_password` or send an empty value to retain the current password. |
+| `GET` | `/api/global` | `GA` | Read editable global SMTP settings. The SMTP password is represented only by `smtp_password_set`. |
+| `PUT` | `/api/global` | `GA` | Update SMTP settings. Omit `smtp_password` or send an empty value to retain the current password. |
 
 ## Playout configuration and capabilities
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -20,6 +20,10 @@ alternative to the web setup:
 sudo -u ffpu ffplayout -i
 ```
 
+The web setup accepts directory paths only during the first initialization.
+To change log, playlist, public, or storage paths later, run `ffplayout -i`
+locally as the service user.
+
 ### Manual Install
 
 **Note:** This is for advanced users only.

--- a/frontend/src/components/config/ConfigGlobal.vue
+++ b/frontend/src/components/config/ConfigGlobal.vue
@@ -53,7 +53,13 @@ async function save() {
         const response = await fetch('/api/global', {
             method: 'PUT',
             headers: { ...configStore.contentType, ...authStore.authHeader },
-            body: JSON.stringify({ ...settings.value, smtp_password: smtpPassword.value }),
+            body: JSON.stringify({
+                smtp_server: settings.value.smtp_server,
+                smtp_user: settings.value.smtp_user,
+                smtp_password: smtpPassword.value,
+                smtp_starttls: settings.value.smtp_starttls,
+                smtp_port: settings.value.smtp_port,
+            }),
         })
 
         if (!response.ok) {
@@ -91,30 +97,7 @@ async function restart(res: boolean) {
     <div v-if="authStore.role === 'global_admin'" class="w-full max-w-200">
         <h2 class="pt-3 text-3xl">{{ t('config.global') }}</h2>
         <form v-if="!loading" class="mt-5 flex flex-col gap-1" @submit.prevent="save">
-            <fieldset class="fieldset">
-                <legend class="fieldset-legend">{{ t('config.logsPath') }}</legend>
-                <input v-model="settings.logs" type="text" class="input w-full" />
-            </fieldset>
-            <fieldset class="fieldset">
-                <legend class="fieldset-legend">{{ t('config.playlistPath') }}</legend>
-                <input v-model="settings.playlists" type="text" class="input w-full" />
-            </fieldset>
-            <fieldset class="fieldset">
-                <legend class="fieldset-legend">{{ t('config.publicPath') }}</legend>
-                <input v-model="settings.public" type="text" class="input w-full" />
-            </fieldset>
-            <fieldset class="fieldset">
-                <legend class="fieldset-legend">{{ t('config.storagePath') }}</legend>
-                <input v-model="settings.storage" type="text" class="input w-full" />
-            </fieldset>
-            <fieldset class="fieldset mt-2">
-                <label class="fieldset-label text-base-content">
-                    <input v-model="settings.shared" type="checkbox" class="checkbox" />
-                    {{ t('config.sharedStorage') }}
-                </label>
-            </fieldset>
-
-            <h3 class="mt-6 text-xl">{{ t('config.smtp') }}</h3>
+            <h3 class="text-xl">{{ t('config.smtp') }}</h3>
             <fieldset class="fieldset">
                 <legend class="fieldset-legend">{{ t('config.smtpServer') }}</legend>
                 <input v-model="settings.smtp_server" type="text" class="input w-full" />

--- a/frontend/src/types/index.d.ts
+++ b/frontend/src/types/index.d.ts
@@ -132,11 +132,6 @@ declare global {
     }
 
     interface GlobalSettings {
-        logs: string
-        playlists: string
-        public: string
-        storage: string
-        shared: boolean
         smtp_server: string
         smtp_user: string
         smtp_password_set: boolean


### PR DESCRIPTION
- remove path and shared-storage settings from the global settings API and UI
- limit authenticated global settings updates to SMTP configuration
- reject unknown path fields in global settings updates
- validate web setup paths as absolute, normalized, and outside protected system directories
- keep packaged ffplayout application directories valid during setup
- preserve local path management through the `ffplayout -i` CLI workflow
- document the setup-only path configuration policy
- add API and setup path validation tests