### PR TITLE
feat(auth): centralize authenticated frontend requests

### DIFF
--- a/frontend/src/components/config/ConfigAudio.vue
+++ b/frontend/src/components/config/ConfigAudio.vue
@@ -54,9 +54,10 @@ function meterValue(value: number | null | undefined, unit: string) {
 }
 
 async function saveAudio() {
-    const response = await configStore.setPlayoutConfig(configStore.playout)
-    if (!response.ok) {
-        indexStore.msgAlert('error', await response.text(), 3)
+    try {
+        await configStore.setPlayoutConfig(configStore.playout)
+    } catch (error) {
+        indexStore.msgAlert('error', error instanceof Error ? error.message : String(error), 3)
         return
     }
 

--- a/frontend/src/components/config/ConfigChannel.vue
+++ b/frontend/src/components/config/ConfigChannel.vue
@@ -10,6 +10,7 @@ import { cloneDeep } from 'es-toolkit/object'
 import GenericModal from '@/components/utils/GenericModal.vue'
 import SvgIcon from '@/components/utils/SvgIcon.vue'
 
+import { authFetch } from '@/composables/authFetch'
 import { useAuth } from '@/stores/auth'
 import { useIndex } from '@/stores/index'
 import { useConfig } from '@/stores/config'
@@ -64,18 +65,11 @@ function newChannel() {
 }
 
 async function addNewChannel() {
-    await fetch('/api/channel', {
+    await authFetch<Channel>('/api/channel', {
         method: 'POST',
         headers: { ...configStore.contentType, ...authStore.authHeader },
         body: JSON.stringify(channel.value),
     })
-        .then(async (response) => {
-            if (!response.ok) {
-                throw new Error(await response.text())
-            }
-
-            return response.json()
-        })
         .then((chl) => {
             configStore.channels.push(cloneDeep(chl as Channel))
             configStore.channelsRaw.push(chl as Channel)
@@ -92,7 +86,7 @@ async function addNewChannel() {
 }
 
 async function updateChannel() {
-    await fetch(`/api/channel/${channel.value.id}`, {
+    await authFetch(`/api/channel/${channel.value.id}`, {
         method: 'PATCH',
         headers: { ...configStore.contentType, ...authStore.authHeader },
         body: JSON.stringify(channel.value),
@@ -161,10 +155,15 @@ async function deleteChannel() {
         return
     }
 
-    const response = await fetch(`/api/channel/${channel.value.id}`, {
-        method: 'DELETE',
-        headers: authStore.authHeader,
-    })
+    try {
+        await authFetch(`/api/channel/${channel.value.id}`, {
+            method: 'DELETE',
+            headers: authStore.authHeader,
+        })
+    } catch {
+        indexStore.msgAlert('error', t('config.deleteChannelFailed'), 2)
+        return
+    }
 
     await configStore.getChannelConfig()
     const previousChannel = configStore.channels[Math.max(0, i.value - 1)]
@@ -179,11 +178,7 @@ async function deleteChannel() {
         await router.replace({ path: route.path, query: { ...route.query, channel: selectedChannel } })
     }
 
-    if (response.status === 200) {
-        indexStore.msgAlert('success', t('config.deleteChannelSuccess'), 2)
-    } else {
-        indexStore.msgAlert('error', t('config.deleteChannelFailed'), 2)
-    }
+    indexStore.msgAlert('success', t('config.deleteChannelSuccess'), 2)
 }
 </script>
 <template>

--- a/frontend/src/components/config/ConfigGlobal.vue
+++ b/frontend/src/components/config/ConfigGlobal.vue
@@ -4,6 +4,7 @@ import { cloneDeep } from 'es-toolkit/object'
 import { isEqual } from 'es-toolkit/predicate'
 import { useI18n } from 'vue-i18n'
 
+import { authFetch } from '@/composables/authFetch'
 import { useAuth } from '@/stores/auth'
 import { useConfig } from '@/stores/config'
 import { useIndex } from '@/stores/index'
@@ -24,15 +25,9 @@ async function getSettings() {
     loading.value = true
 
     try {
-        const response = await fetch('/api/global', {
+        settings.value = await authFetch<GlobalSettings>('/api/global', {
             headers: authStore.authHeader,
         })
-
-        if (!response.ok) {
-            throw new Error(await response.text())
-        }
-
-        settings.value = await response.json()
         savedSettings.value = cloneDeep(settings.value)
         smtpPassword.value = ''
     } catch {
@@ -48,7 +43,7 @@ function isChanged() {
 
 async function save() {
     try {
-        const response = await fetch('/api/global', {
+        settings.value = await authFetch<GlobalSettings>('/api/global', {
             method: 'PUT',
             headers: { ...configStore.contentType, ...authStore.authHeader },
             body: JSON.stringify({
@@ -60,11 +55,6 @@ async function save() {
             }),
         })
 
-        if (!response.ok) {
-            throw new Error(await response.text())
-        }
-
-        settings.value = await response.json()
         savedSettings.value = cloneDeep(settings.value)
         smtpPassword.value = ''
         indexStore.msgAlert('success', t('config.updateGlobalSuccess'), 2)

--- a/frontend/src/components/config/ConfigPlayout.vue
+++ b/frontend/src/components/config/ConfigPlayout.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 
 import GenericModal from '@/components/utils/GenericModal.vue'
 
+import { authFetch } from '@/composables/authFetch'
 import { useAuth } from '@/stores/auth'
 import { useIndex } from '@/stores/index'
 import { useConfig } from '@/stores/config'
@@ -229,29 +230,17 @@ async function onSubmitPlayout() {
     try {
         const update = await configStore.setPlayoutConfig(configStore.playout)
         configStore.onetimeInfo = true
-
-        if (!update.ok) {
-            const message = await update.text()
-            const summary = t('config.updatePlayoutFailed')
-            indexStore.msgAlert('error', message ? `${summary}: ${message}` : summary, 3)
-            return
-        }
-
-        const { requires_restart: requiresRestart } = (await update.json()) as { requires_restart: boolean }
+        const { requires_restart: requiresRestart } = update
 
         indexStore.msgAlert('success', t('config.updatePlayoutSuccess'), 2)
 
         const id = configStore.channels[configStore.i]?.id
-        const response = await fetch(`/api/control/${id}/process`, {
+        const response = await authFetch<string>(`/api/control/${id}/process`, {
             method: 'POST',
             headers: { ...configStore.contentType, ...authStore.authHeader },
             body: JSON.stringify({ command: 'status' }),
         })
-        if (!response.ok) {
-            throw new Error(await response.text())
-        }
-
-        if ((await response.json()) === 'active' && requiresRestart) {
+        if (response === 'active' && requiresRestart) {
             configStore.showRestartModal = true
         }
 

--- a/frontend/src/components/config/ConfigUser.vue
+++ b/frontend/src/components/config/ConfigUser.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { authFetch } from '@/composables/authFetch'
 import { useVariables } from '@/composables/variables'
 import { useAuth } from '@/stores/auth'
 import { useIndex } from '@/stores/index'
@@ -42,11 +43,10 @@ onMounted(() => {
 })
 
 async function getUsers() {
-    fetch('/api/users', {
+    authFetch<User[]>('/api/users', {
         method: 'GET',
         headers: authStore.authHeader,
     })
-        .then((response) => response.json())
         .then((data) => {
             users.value = data
 
@@ -62,11 +62,10 @@ function onChange(event: Event) {
 }
 
 async function getUserConfig() {
-    await fetch(`/api/user/${selected.value}`, {
+    await authFetch<User>(`/api/user/${selected.value}`, {
         method: 'GET',
         headers: authStore.authHeader,
     })
-        .then((response) => response.json())
         .then((data) => {
             configStore.configUser = data
         })
@@ -76,7 +75,7 @@ async function deleteUser() {
     if (configStore.configUser.id === configStore.currentUser) {
         indexStore.msgAlert('error', t('user.deleteNotPossible'), 2)
     } else {
-        await fetch(`/api/user/${configStore.configUser.id}`, {
+        await authFetch(`/api/user/${configStore.configUser.id}`, {
             method: 'DELETE',
             headers: authStore.authHeader,
         })
@@ -116,15 +115,14 @@ async function addUser(add: boolean) {
 
         if (user.value.username && user.value.password && user.value.password === user.value.confirm) {
             await authStore.inspectToken()
-            const update = await configStore.addNewUser(user.value)
-            showUserModal.value = false
+            try {
+                await configStore.addNewUser(user.value)
+                showUserModal.value = false
 
-            if (update.status === 200) {
                 indexStore.msgAlert('success', t('user.addSuccess'), 2)
-
                 await getUsers()
                 await getUserConfig()
-            } else {
+            } catch {
                 indexStore.msgAlert('error', t('user.addFailed'), 3)
             }
 
@@ -149,11 +147,10 @@ async function onSubmitUser() {
     }
 
     await authStore.inspectToken()
-    const update = await configStore.setUserConfig(configStore.configUser)
-
-    if (update.status === 200) {
+    try {
+        await configStore.setUserConfig(configStore.configUser)
         indexStore.msgAlert('success', t('user.updateSuccess'), 2)
-    } else {
+    } catch {
         indexStore.msgAlert('error', t('user.updateFailed'), 2)
     }
 

--- a/frontend/src/components/player/PlayerControl.vue
+++ b/frontend/src/components/player/PlayerControl.vue
@@ -12,6 +12,7 @@ import { throttle } from 'es-toolkit/function'
 import { storeToRefs } from 'pinia'
 import { useEventSource, useElementSize } from '@vueuse/core'
 
+import { authFetch } from '@/composables/authFetch'
 import { stringFormatter } from '@/composables/helper'
 import { useAuth } from '@/stores/auth'
 import { useIndex } from '@/stores/index'
@@ -250,11 +251,7 @@ const applyVolumeControl = throttle(async () => {
     configStore.playout.audio.volume = volume
 
     try {
-        const response = await configStore.applyAudioEffects(volume)
-
-        if (!response.ok) {
-            throw new Error(await response.text())
-        }
+        await configStore.applyAudioEffects(volume)
     } catch (error) {
         indexStore.msgAlert('error', error instanceof Error ? error.message : String(error), 3)
     }
@@ -291,7 +288,7 @@ const controlProcess = throttle(async (state: string) => {
         Control playout (start, stop, restart)
     */
     const id = configStore.channels[configStore.i]?.id
-    await fetch(`/api/control/${id}/process`, {
+    await authFetch(`/api/control/${id}/process`, {
         method: 'POST',
         headers: { ...configStore.contentType, ...authStore.authHeader },
         body: JSON.stringify({ command: state }),
@@ -315,7 +312,7 @@ const controlPlayout = throttle(async (state: string) => {
     */
     const id = configStore.channels[configStore.i]?.id
 
-    await fetch(`/api/control/${id}/playout`, {
+    await authFetch(`/api/control/${id}/playout`, {
         method: 'POST',
         headers: { ...configStore.contentType, ...authStore.authHeader },
         body: JSON.stringify({ control: state }),

--- a/frontend/src/components/player/PlaylistGenerator.vue
+++ b/frontend/src/components/player/PlaylistGenerator.vue
@@ -7,6 +7,7 @@ import { useI18n } from 'vue-i18n'
 import { useWindowSize } from '@vueuse/core'
 import { isEqual } from 'es-toolkit/predicate'
 
+import { authFetch } from '@/composables/authFetch'
 import { playlistOperations } from '@/composables/helper'
 import { useAuth } from '@/stores/auth'
 import { useIndex } from '@/stores/index'
@@ -140,18 +141,11 @@ async function generatePlaylist() {
         }
     }
 
-    await fetch(`/api/playlist/${configStore.channels[configStore.i]?.id}/generate/${playlistStore.listDate}`, {
+    await authFetch<any>(`/api/playlist/${configStore.channels[configStore.i]?.id}/generate/${playlistStore.listDate}`, {
         method: 'POST',
         headers: { ...configStore.contentType, ...authStore.authHeader },
         body: JSON.stringify(body),
     })
-        .then(async (response) => {
-            if (!response.ok) {
-                throw new Error(await response.text())
-            }
-
-            return response.json()
-        })
         .then((response: any) => {
             playlistStore.playlist = processPlaylist(playlistStore.listDate, response.program, false)
             indexStore.msgAlert('success', t('player.generateDone'), 2)

--- a/frontend/src/composables/authFetch.ts
+++ b/frontend/src/composables/authFetch.ts
@@ -1,0 +1,105 @@
+import { useAuth } from '@/stores/auth'
+
+type AuthResponseType = 'json' | 'text' | 'blob' | 'arrayBuffer'
+
+export type AuthFetchOptions = RequestInit & {
+    responseType?: AuthResponseType
+}
+
+export class AuthFetchError<T = unknown> extends Error {
+    constructor(
+        public readonly response: Response,
+        public readonly data: T,
+    ) {
+        super(fetchErrorMessage(response, data))
+    }
+}
+
+function fetchErrorMessage(response: Response, data: unknown): string {
+    if (typeof data === 'string' && data) {
+        return data
+    }
+    if (data && typeof data === 'object') {
+        const detail = 'detail' in data && typeof data.detail === 'string' ? data.detail : undefined
+        const error = 'error' in data && typeof data.error === 'string' ? data.error : undefined
+
+        if (detail || error) {
+            return detail ?? error ?? `Request failed with status ${response.status}`
+        }
+    }
+
+    return `Request failed with status ${response.status}`
+}
+
+/**
+ * Sends an authenticated request and returns its parsed response body.
+ */
+export async function authFetch<T = unknown>(
+    input: RequestInfo | URL,
+    { responseType, ...init }: AuthFetchOptions = {},
+): Promise<T> {
+    const response = await authFetchRaw(input, init)
+    const type = responseType ?? defaultResponseType(response)
+
+    if (!response.ok) {
+        throw new AuthFetchError(response, await readResponse(response, type))
+    }
+    if (response.status === 204) {
+        return undefined as T
+    }
+
+    return (await readResponse(response, type)) as T
+}
+
+/**
+ * Sends an authenticated request and returns the unparsed response. Use this
+ * for downloads and callers that need headers or streaming response bodies.
+ */
+export async function authFetchRaw(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    const auth = useAuth()
+
+    await auth.inspectToken()
+    if (!auth.isLogin) {
+        return new Response(null, { status: 401, statusText: 'Authentication required' })
+    }
+
+    const request = new Request(input, init)
+    const send = async () => {
+        const headers = new Headers(request.headers)
+        headers.set('Authorization', `Bearer ${auth.jwtToken}`)
+
+        return fetch(new Request(request.clone(), { headers }))
+    }
+
+    const accessToken = auth.jwtToken
+    let response = await send()
+    if (response.status !== 401) {
+        return response
+    }
+
+    // Another request may have completed the shared refresh while this one
+    // was in flight. In that case retry with its already-current access token.
+    if (auth.jwtToken === accessToken && !(await auth.refreshToken())) {
+        return response
+    }
+
+    response = await send()
+    return response
+}
+
+function defaultResponseType(response: Response): AuthResponseType {
+    return response.headers.get('content-type')?.includes('application/json') ? 'json' : 'text'
+}
+
+async function readResponse(response: Response, type: AuthResponseType): Promise<unknown> {
+    switch (type) {
+        case 'json':
+            return response.json()
+        case 'blob':
+            return response.blob()
+        case 'arrayBuffer':
+            return response.arrayBuffer()
+        case 'text':
+            return response.text()
+    }
+}

--- a/frontend/src/composables/fileAccess.ts
+++ b/frontend/src/composables/fileAccess.ts
@@ -1,3 +1,5 @@
+import { authFetch } from '@/composables/authFetch'
+
 type FileAccessResponse = {
     access: string
     expires_in_seconds: number
@@ -12,26 +14,18 @@ function fileUrl(channelId: number | undefined, path: string, access: string): s
 export async function createFilePreviewUrl(
     channelId: number | undefined,
     path: string,
-    authHeader: HeadersInit
 ): Promise<string> {
     if (!channelId) {
         throw new Error('Missing channel id')
     }
 
-    const response = await fetch(`/api/file/${channelId}/access-token`, {
+    const token = await authFetch<FileAccessResponse>(`/api/file/${channelId}/access-token`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            ...authHeader,
         },
         body: JSON.stringify({ filename: path }),
     })
-
-    if (!response.ok) {
-        throw new Error(await response.text())
-    }
-
-    const token = (await response.json()) as FileAccessResponse
 
     return fileUrl(channelId, path, token.access)
 }

--- a/frontend/src/composables/useFileUpload.ts
+++ b/frontend/src/composables/useFileUpload.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue'
 
+import { authFetch, authFetchRaw } from '@/composables/authFetch'
 import { useHelper } from '@/composables/helper'
 
 interface UploadRequestOptions {
@@ -91,16 +92,9 @@ export const useFileUpload = () => {
         url.searchParams.set('size', file.size.toString())
         url.searchParams.set('batch_id', batchId)
 
-        const response = await fetch(url, {
+        return authFetch<{ received_ranges: [number, number][] }>(url, {
             headers: request.headers,
         })
-        if (!response.ok) {
-            throw new Error(await errMsg(response))
-        }
-
-        return (await response.json()) as {
-            received_ranges: [number, number][]
-        }
     }
 
     async function parseResponse<T>(resp: Response, responseType: 'json' | 'text' = 'text'): Promise<T> {
@@ -164,7 +158,7 @@ export const useFileUpload = () => {
                     }
                 }
 
-                const resp = await fetch(request.url, {
+                const resp = await authFetchRaw(request.url, {
                     method: request.method || 'PUT',
                     headers: request.headers,
                     body: form,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -5,6 +5,7 @@ import { createPinia } from 'pinia'
 import { createHead } from '@unhead/vue/client'
 
 import i18nInstance from './i18n.ts'
+import { initAuthChannel } from './stores/auth.ts'
 
 import App from './App.vue'
 import router from './router/index.ts'
@@ -24,6 +25,7 @@ const head = createHead({
 app.use(i18nInstance)
 app.use(head)
 app.use(createPinia())
+initAuthChannel()
 app.use(router)
 
 app.mount('#app')

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { jwtDecode } from 'jwt-decode'
+import { authFetch } from '@/composables/authFetch'
 import { useIndex } from '@/stores/index'
 
 type LoginResult = {
@@ -7,7 +8,62 @@ type LoginResult = {
     verificationRequired: boolean
 }
 
+type AuthChannelMessage =
+    | { type: 'tokens-updated'; access: string; refresh: string }
+    | { type: 'logout' }
+
+const AUTH_CHANNEL_NAME = 'ffplayout-auth'
+
 let refreshRequest: Promise<boolean> | null = null
+let authChannel: BroadcastChannel | null = null
+
+function broadcastAuthMessage(message: AuthChannelMessage) {
+    authChannel?.postMessage(message)
+}
+
+function isAuthChannelMessage(message: unknown): message is AuthChannelMessage {
+    if (!message || typeof message !== 'object' || !('type' in message)) {
+        return false
+    }
+
+    if (message.type === 'logout') {
+        return true
+    }
+
+    return (
+        message.type === 'tokens-updated' &&
+        'access' in message &&
+        typeof message.access === 'string' &&
+        'refresh' in message &&
+        typeof message.refresh === 'string'
+    )
+}
+
+/** Starts tab-to-tab synchronization after Pinia has been installed. */
+export function initAuthChannel() {
+    if (authChannel || typeof BroadcastChannel === 'undefined') {
+        return
+    }
+
+    authChannel = new BroadcastChannel(AUTH_CHANNEL_NAME)
+    authChannel.addEventListener('message', (event: MessageEvent<unknown>) => {
+        if (!isAuthChannelMessage(event.data)) {
+            return
+        }
+
+        const auth = useAuth()
+        if (event.data.type === 'logout') {
+            auth.removeToken(false)
+            return
+        }
+
+        try {
+            auth.updateToken(event.data.access, event.data.refresh, false)
+        } catch {
+            auth.removeToken(false)
+        }
+    })
+}
 
 export const useAuth = defineStore('auth', {
     state: () => ({
@@ -24,7 +80,7 @@ export const useAuth = defineStore('auth', {
 
     getters: {},
     actions: {
-        updateToken(token: string, refresh: string) {
+        updateToken(token: string, refresh: string, broadcast: boolean = true) {
             const decodedToken = jwtDecode<JwtPayloadExt>(token)
             const decodedRefresh = jwtDecode<JwtPayloadExt>(refresh)
             if (decodedToken.token_type !== 'access' || decodedRefresh.token_type !== 'refresh') {
@@ -41,9 +97,13 @@ export const useAuth = defineStore('auth', {
             this.authHeader = { Authorization: `Bearer ${token}` }
             this.id = decodedToken.id
             this.role = decodedToken.role
+
+            if (broadcast) {
+                broadcastAuthMessage({ type: 'tokens-updated', access: token, refresh })
+            }
         },
 
-        removeToken() {
+        removeToken(broadcast: boolean = true) {
             localStorage.removeItem('token')
             localStorage.removeItem('refresh')
 
@@ -54,6 +114,10 @@ export const useAuth = defineStore('auth', {
             this.id = 0
             this.role = ''
             this.uuid = null
+
+            if (broadcast) {
+                broadcastAuthMessage({ type: 'logout' })
+            }
         },
 
         async logout() {
@@ -77,7 +141,7 @@ export const useAuth = defineStore('auth', {
         beginVerification() {
             // A previous session must not redirect the pending two-factor
             // login to the authenticated part of the application.
-            this.removeToken()
+            this.removeToken(false)
             this.verificationPending = true
         },
 
@@ -225,20 +289,7 @@ export const useAuth = defineStore('auth', {
 
         async selectAuthUser() {
             const store = useIndex()
-            await fetch(`/api/user/${this.id}`, {
-                headers: this.authHeader,
-            })
-                .then(async (resp) => {
-                    if (resp.status >= 400) {
-                        const msg = (await resp.json())?.error ?? (await resp.text())
-
-                        if (msg.includes('Unauthorized')) {
-                            this.removeToken()
-                        }
-                        throw new Error(msg)
-                    }
-                    return resp.json()
-                })
+            await authFetch<User>(`/api/user/${this.id}`)
                 .then((response: any) => {
                     if (response) {
                         this.id = response.id
@@ -251,20 +302,7 @@ export const useAuth = defineStore('auth', {
         },
 
         async obtainUuid() {
-            await fetch('/api/generate-uuid', {
-                method: 'POST',
-                headers: this.authHeader,
-            })
-                .then(async (resp) => {
-                    if (!resp.ok) {
-                        if (resp.status === 401) {
-                            this.removeToken()
-                        }
-                        this.uuid = null
-                    }
-
-                    return resp.json()
-                })
+            await authFetch<{ uuid: string }>('/api/generate-uuid', { method: 'POST' })
                 .then((response: any) => {
                     this.uuid = response.uuid
                 })

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -2,6 +2,7 @@ import { cloneDeep } from 'es-toolkit/object'
 import { defineStore } from 'pinia'
 import { useRouter } from 'vue-router'
 
+import { authFetch } from '@/composables/authFetch'
 import { useAuth } from './auth'
 import { useIndex } from './index'
 import { i18n } from '../i18n'
@@ -63,30 +64,23 @@ export const useConfig = defineStore('config', {
             const authStore = useAuth()
             const indexStore = useIndex()
 
-            let statusCode = 0
-            await fetch('/api/channels', {
+            await authFetch<Channel[]>('/api/channels', {
                 method: 'GET',
                 headers: authStore.authHeader,
             })
-                .then((response) => {
-                    statusCode = response.status
-
-                    return response
-                })
-                .then((response) => response.json())
                 .then((objs) => {
                     if (!objs[0]) {
                         this.logout()
                         throw new Error('User not found')
                     }
 
-                    this.timezone = objs[0].timezone
+                    this.timezone = objs[0].timezone ?? 'UTC'
                     this.channels = objs
                     this.channelsRaw = cloneDeep(objs)
                     this.configCount = objs.length
                 })
                 .catch((e) => {
-                    if (statusCode === 401) {
+                    if (e.response?.status === 401) {
                         this.logout()
                     }
 
@@ -117,11 +111,10 @@ export const useConfig = defineStore('config', {
             const indexStore = useIndex()
             const id = this.channels[this.i]?.id
 
-            await fetch(`/api/playout/config/${id}`, {
+            await authFetch<PlayoutConfigExt>(`/api/playout/config/${id}`, {
                 method: 'GET',
                 headers: authStore.authHeader,
             })
-                .then((resp) => resp.json())
                 .then((data: PlayoutConfigExt) => {
                     data.playlist.startInSec = timeToSeconds(data.playlist.day_start ?? 0)
                     data.playlist.lengthInSec = timeToSeconds(data.playlist.length ?? this.playlistLength)
@@ -139,11 +132,10 @@ export const useConfig = defineStore('config', {
             const indexStore = useIndex()
             const id = this.channels[this.i]?.id
 
-            await fetch(`/api/playout/outputs/${id}`, {
+            await authFetch<PlayoutOutput[]>(`/api/playout/outputs/${id}`, {
                 method: 'GET',
                 headers: authStore.authHeader,
             })
-                .then((resp) => resp.json())
                 .then((data: PlayoutOutput[]) => {
 
                     this.outputs = data
@@ -158,11 +150,10 @@ export const useConfig = defineStore('config', {
             const indexStore = useIndex()
             const id = this.channels[this.i]?.id
 
-            await fetch(`/api/playout/codecs/${id}`, {
+            await authFetch<PlayoutCodecOptions>(`/api/playout/codecs/${id}`, {
                 method: 'GET',
                 headers: authStore.authHeader,
             })
-                .then((resp) => resp.json())
                 .then((data: PlayoutCodecOptions) => {
                     this.outputCodecs = data
                 })
@@ -180,7 +171,7 @@ export const useConfig = defineStore('config', {
             this.playout.playlist.startInSec = timeToSeconds(obj.playlist.day_start)
             this.playout.playlist.lengthInSec = timeToSeconds(obj.playlist.length)
 
-            const update = await fetch(`/api/playout/config/${id}`, {
+            const update = await authFetch<{ requires_restart: boolean }>(`/api/playout/config/${id}`, {
                 method: 'PUT',
                 headers: { ...this.contentType, ...authStore.authHeader },
                 body: JSON.stringify(obj),
@@ -193,7 +184,7 @@ export const useConfig = defineStore('config', {
             const authStore = useAuth()
             const id = this.channels[this.i]?.id
 
-            return fetch(`/api/control/${id}/audio`, {
+            return authFetch<void>(`/api/control/${id}/audio`, {
                 method: 'PUT',
                 headers: { ...this.contentType, ...authStore.authHeader },
                 body: JSON.stringify({ volume }),
@@ -203,11 +194,10 @@ export const useConfig = defineStore('config', {
         async getUserConfig() {
             const authStore = useAuth()
 
-            await fetch('/api/user', {
+            await authFetch<User>('/api/user', {
                 method: 'GET',
                 headers: authStore.authHeader,
             })
-                .then((response) => response.json())
                 .then((data) => {
                     if (data.id === 0) {
                         this.logout()
@@ -222,7 +212,7 @@ export const useConfig = defineStore('config', {
         async setUserConfig(obj: any) {
             const authStore = useAuth()
 
-            const update = await fetch(`/api/user/${obj.id}`, {
+            const update = await authFetch<User>(`/api/user/${obj.id}`, {
                 method: 'PUT',
                 headers: { ...this.contentType, ...authStore.authHeader },
                 body: JSON.stringify(obj),
@@ -235,7 +225,7 @@ export const useConfig = defineStore('config', {
             const authStore = useAuth()
             delete user.confirm
 
-            const update = await fetch('/api/user', {
+            const update = await authFetch<User>('/api/user', {
                 method: 'Post',
                 headers: { ...this.contentType, ...authStore.authHeader },
                 body: JSON.stringify(user),
@@ -250,7 +240,7 @@ export const useConfig = defineStore('config', {
                 const indexStore = useIndex()
                 const id = this.channels[this.i]?.id
 
-                await fetch(`/api/control/${id}/process`, {
+                await authFetch(`/api/control/${id}/process`, {
                     method: 'POST',
                     headers: { ...this.contentType, ...authStore.authHeader },
                     body: JSON.stringify({ command: 'restart' }),

--- a/frontend/src/stores/media.ts
+++ b/frontend/src/stores/media.ts
@@ -1,9 +1,10 @@
 import { defineStore } from 'pinia'
 
-import { useAuth } from './auth'
-import { useIndex } from './index'
-import { useConfig } from './config'
+import { authFetch } from '@/composables/authFetch'
 import { i18n } from '@/i18n'
+import { useAuth } from './auth'
+import { useConfig } from './config'
+import { useIndex } from './index'
 
 import { playlistOperations } from '../composables/helper'
 
@@ -33,25 +34,11 @@ export const useMedia = defineStore('media', {
             const crumbs: Crumb[] = []
             let root = '/'
 
-            await fetch(`/api/file/${id}/browse`, {
+            await authFetch<any>(`/api/file/${id}/browse`, {
                 method: 'POST',
                 headers: { ...configStore.contentType, ...authStore.authHeader },
                 body: JSON.stringify({ source: path, folders_only: foldersOnly }),
             })
-                .then((response) => {
-                    if (response.status === 200) {
-                        return response.json()
-                    } else {
-                        indexStore.msgAlert('error', i18n.t('media.notExists'), 3)
-
-                        return {
-                            source: '',
-                            parent: '',
-                            folders: [],
-                            files: [],
-                        }
-                    }
-                })
                 .then((data) => {
                     const pathStr = `${data.parent}/` + data.source
                     const pathArr = pathStr.split('/')
@@ -81,6 +68,9 @@ export const useMedia = defineStore('media', {
                         data.folders = data.folders.map((i: any) => ({ uid: genUID(), name: i }))
                         this.folderTree = data
                     }
+                })
+                .catch(() => {
+                    indexStore.msgAlert('error', i18n.t('media.notExists'), 3)
                 })
 
             this.isLoading = false

--- a/frontend/src/stores/playlist.ts
+++ b/frontend/src/stores/playlist.ts
@@ -7,6 +7,7 @@ import timezone from 'dayjs/plugin/timezone.js'
 
 import { defineStore } from 'pinia'
 
+import { authFetch } from '@/composables/authFetch'
 import { i18n } from '@/i18n'
 import { playlistOperations } from '@/composables/helper'
 import { useAuth } from '@/stores/auth'
@@ -44,17 +45,10 @@ export const usePlaylist = defineStore('playlist', {
             const indexStore = useIndex()
             const channel = configStore.channels[configStore.i]?.id
 
-            await fetch(`/api/playlist/${channel}?date=${date}`, {
+            await authFetch<Playlist>(`/api/playlist/${channel}?date=${date}`, {
                 method: 'GET',
                 headers: authStore.authHeader,
             })
-                .then(async (response) => {
-                    if (!response.ok) {
-                        throw new Error(await response.text())
-                    }
-
-                    return response.json()
-                })
                 .then((data: Playlist) => {
                     if (data.program) {
                         const programData = processPlaylist(date, data.program, false)

--- a/frontend/src/views/LoggingView.vue
+++ b/frontend/src/views/LoggingView.vue
@@ -23,6 +23,7 @@ dayjs.extend(LocalizedFormat)
 dayjs.extend(timezone)
 dayjs.extend(utc)
 
+import { authFetch, authFetchRaw } from '@/composables/authFetch'
 import { useAuth } from '@/stores/auth'
 import { useConfig } from '@/stores/config'
 import { useIndex } from '@/stores/index'
@@ -104,21 +105,16 @@ async function getLog() {
         date = ''
     }
 
-    await fetch(
+    await authFetch<string>(
         `/api/log/${configStore.channels[configStore.i]?.id}?date=${date}&timezone=${encodeURIComponent(
             configStore.timezone
         )}`,
         {
             method: 'GET',
             headers: authStore.authHeader,
+            responseType: 'text',
         }
     )
-        .then(async (response) => {
-            if (!response.ok) {
-                throw new Error(await response.text())
-            }
-            return response.text()
-        })
         .then((data) => {
             currentLog.value = data
 
@@ -139,7 +135,7 @@ async function downloadLog() {
         date = ''
     }
 
-    const response = await fetch(
+    const response = await authFetchRaw(
         `/api/log/${id}?date=${date}&timezone=${encodeURIComponent(configStore.timezone)}&download=true`,
         {
             method: 'GET',

--- a/frontend/src/views/MediaView.vue
+++ b/frontend/src/views/MediaView.vue
@@ -16,6 +16,7 @@ import { useMedia } from '@/stores/media'
 import GenericModal from '@/components/utils/GenericModal.vue'
 import VideoPlayer from '@/components/utils/VideoPlayer.vue'
 
+import { authFetch } from '@/composables/authFetch'
 import { stringFormatter } from '@/composables/helper'
 import { createFilePreviewUrl } from '@/composables/fileAccess'
 import { useFileUpload } from '@/composables/useFileUpload'
@@ -144,17 +145,13 @@ async function handleDrop(event: any, targetFolder: any, isParent: boolean | nul
     }
 
     if (source !== target) {
-        await fetch(`/api/file/${configStore.channels[configStore.i]?.id}/rename`, {
+        await authFetch<void>(`/api/file/${configStore.channels[configStore.i]?.id}/rename`, {
             method: 'POST',
             headers: { ...configStore.contentType, ...authStore.authHeader },
             body: JSON.stringify({ source, target }),
         })
-            .then(async (res) => {
-                if (res.status >= 400) {
-                    indexStore.msgAlert('error', await res.json(), 3)
-                } else {
-                    mediaStore.getTree(mediaStore.folderTree.source)
-                }
+            .then(() => {
+                mediaStore.getTree(mediaStore.folderTree.source)
             })
             .catch((e) => {
                 indexStore.msgAlert('error', `${t('media.moveError')}: ${e}`, 3)
@@ -177,7 +174,6 @@ async function setPreviewData(path: string) {
         previewUrl.value = await createFilePreviewUrl(
             configStore.channels[configStore.i]?.id,
             fullPath,
-            authStore.authHeader
         )
     }
     catch (error) {
@@ -220,15 +216,12 @@ async function deleteFileOrFolder(del: boolean) {
     showDeleteModal.value = false
 
     if (del) {
-        await fetch(`/api/file/${configStore.channels[configStore.i]?.id}/remove`, {
+        await authFetch<void>(`/api/file/${configStore.channels[configStore.i]?.id}/remove`, {
             method: 'POST',
             headers: { ...configStore.contentType, ...authStore.authHeader },
             body: JSON.stringify({ source: deleteName.value, recursive: recursive.value }),
         })
-            .then(async (response) => {
-                if (response.status !== 200) {
-                    indexStore.msgAlert('error', `${await response.text()}`, 5)
-                }
+            .then(() => {
                 mediaStore.getTree(mediaStore.folderTree.source)
             })
             .catch((e) => {
@@ -256,7 +249,7 @@ async function renameFile(ren: boolean) {
     showRenameModal.value = false
 
     if (ren && renameOldName.value !== renameNewName.value) {
-        await fetch(`/api/file/${configStore.channels[configStore.i]?.id}/rename`, {
+        await authFetch<void>(`/api/file/${configStore.channels[configStore.i]?.id}/rename`, {
             method: 'POST',
             headers: { ...configStore.contentType, ...authStore.authHeader },
             body: JSON.stringify({
@@ -264,12 +257,8 @@ async function renameFile(ren: boolean) {
                 target: `${renameOldPath.value}${renameNewName.value}`,
             }),
         })
-            .then(async (res) => {
-                if (res.status >= 400) {
-                    indexStore.msgAlert('error', await res.text(), 3)
-                } else {
-                    mediaStore.getTree(mediaStore.folderTree.source)
-                }
+            .then(() => {
+                mediaStore.getTree(mediaStore.folderTree.source)
             })
             .catch((e) => {
                 indexStore.msgAlert('error', `${t('media.moveError')}: ${e}`, 3)
@@ -299,7 +288,7 @@ async function createFolder(create: boolean) {
             return
         }
 
-        await fetch(`/api/file/${configStore.channels[configStore.i]?.id}/create-folder`, {
+        await authFetch(`/api/file/${configStore.channels[configStore.i]?.id}/create-folder`, {
             method: 'POST',
             headers: { ...configStore.contentType, ...authStore.authHeader },
             body: JSON.stringify({ source: path }),

--- a/frontend/src/views/MessageView.vue
+++ b/frontend/src/views/MessageView.vue
@@ -6,6 +6,7 @@ import { useHead } from '@unhead/vue'
 
 import GenericModal from '@/components/utils/GenericModal.vue'
 
+import { authFetch } from '@/composables/authFetch'
 import { useAuth } from '@/stores/auth'
 import { useIndex } from '@/stores/index'
 import { useConfig } from '@/stores/config'
@@ -72,11 +73,10 @@ watch([i], () => {
 })
 
 async function getPreset(index: number) {
-    fetch(`/api/presets/${configStore.channels[configStore.i]?.id}`, {
+    authFetch<TextPreset[]>(`/api/presets/${configStore.channels[configStore.i]?.id}`, {
         method: 'GET',
         headers: authStore.authHeader,
     })
-        .then((response) => response.json())
         .then((data) => {
             if (index === -1) {
                 presets.value = [{ value: -1, name: '' }]
@@ -94,11 +94,11 @@ async function getPreset(index: number) {
 }
 
 async function getFontFamilies() {
-    const response = await fetch('/api/text/fonts', {
+    const response = await authFetch<string[]>('/api/text/fonts', {
         method: 'GET',
         headers: authStore.authHeader,
     })
-    fontFamilies.value = response.ok ? await response.json() : []
+    fontFamilies.value = response
 }
 
 function onChange(event: any) {
@@ -109,15 +109,15 @@ function onChange(event: any) {
 
 async function savePreset() {
     if (selected.value) {
-        const response = await fetch(`/api/presets/${configStore.channels[configStore.i]?.id}/${form.value.id}`, {
-            method: 'PUT',
-            headers: { ...configStore.contentType, ...authStore.authHeader },
-            body: JSON.stringify(form.value),
-        })
+        try {
+            await authFetch<TextPreset>(`/api/presets/${configStore.channels[configStore.i]?.id}/${form.value.id}`, {
+                method: 'PUT',
+                headers: { ...configStore.contentType, ...authStore.authHeader },
+                body: JSON.stringify(form.value),
+            })
 
-        if (response.status === 200) {
             indexStore.msgAlert('success', t('message.saveDone'), 2)
-        } else {
+        } catch {
             indexStore.msgAlert('error', t('message.saveFailed'), 2)
         }
     }
@@ -133,16 +133,16 @@ async function createNewPreset(create: boolean) {
             channel_id: configStore.channels[configStore.i]?.id,
         }
 
-        const response = await fetch(`/api/presets/${configStore.channels[configStore.i]?.id}/`, {
-            method: 'POST',
-            headers: { ...configStore.contentType, ...authStore.authHeader },
-            body: JSON.stringify(preset),
-        })
+        try {
+            await authFetch<TextPreset>(`/api/presets/${configStore.channels[configStore.i]?.id}/`, {
+                method: 'POST',
+                headers: { ...configStore.contentType, ...authStore.authHeader },
+                body: JSON.stringify(preset),
+            })
 
-        if (response.status === 200) {
             indexStore.msgAlert('success', t('message.saveDone'), 2)
             getPreset(-1)
-        } else {
+        } catch {
             indexStore.msgAlert('error', t('message.saveFailed'), 2)
         }
     }
@@ -154,7 +154,7 @@ async function deletePreset(del: boolean) {
     showDeleteModal.value = false
 
     if (del && selected.value && selected.value !== '') {
-        await fetch(`/api/presets/${configStore.channels[configStore.i]?.id}/${form.value.id}`, {
+        await authFetch(`/api/presets/${configStore.channels[configStore.i]?.id}/${form.value.id}`, {
             method: 'DELETE',
             headers: authStore.authHeader,
         })
@@ -164,15 +164,15 @@ async function deletePreset(del: boolean) {
 }
 
 async function submitMessage() {
-    const response = await fetch(`/api/control/${configStore.channels[configStore.i]?.id}/text`, {
-        method: 'POST',
-        headers: { ...configStore.contentType, ...authStore.authHeader },
-        body: JSON.stringify(form.value),
-    })
+    try {
+        await authFetch<void>(`/api/control/${configStore.channels[configStore.i]?.id}/text`, {
+            method: 'POST',
+            headers: { ...configStore.contentType, ...authStore.authHeader },
+            body: JSON.stringify(form.value),
+        })
 
-    if (response.status === 200) {
         indexStore.msgAlert('success', t('message.sendDone'), 2)
-    } else {
+    } catch {
         indexStore.msgAlert('error', t('message.sendFailed'), 2)
     }
 }

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -38,6 +38,7 @@ import VideoPlayer from '@/components/utils/VideoPlayer.vue'
 import TimePicker from '@/components/utils/TimePicker.vue'
 import SvgIcon from '@/components/utils/SvgIcon.vue'
 
+import { authFetch } from '@/composables/authFetch'
 import { stringFormatter, playlistOperations } from '@/composables/helper'
 import { createFilePreviewUrl } from '@/composables/fileAccess'
 import { useAuth } from '@/stores/auth'
@@ -166,7 +167,6 @@ async function setPreviewData(path: string) {
             previewUrl.value = await createFilePreviewUrl(
                 configStore.channels[configStore.i]?.id,
                 fullPath,
-                authStore.authHeader
             )
         }
         catch (error) {
@@ -335,7 +335,7 @@ async function importPlaylist(imp: boolean) {
         formData.append(textFile.value[0].name, textFile.value[0])
 
         playlistStore.isLoading = true
-        await fetch(
+        await authFetch<any>(
             `/api/file/${configStore.channels[configStore.i]?.id}/import?file=${textFile.value[0].name}&date=${
                 listDate.value
             }`,
@@ -345,13 +345,6 @@ async function importPlaylist(imp: boolean) {
                 body: formData,
             },
         )
-            .then(async (response) => {
-                if (response.status > 203) {
-                    throw new Error(await response.text())
-                }
-
-                return response.json()
-            })
             .then(async (response) => {
                 indexStore.msgAlert('success', response, 2)
                 await playlistStore.getPlaylist(listDate.value)
@@ -375,7 +368,7 @@ async function savePlaylist(save: boolean) {
 
         const saveList = processPlaylist(listDate.value, cloneDeep(playlistStore.playlist), true)
 
-        await fetch(`/api/playlist/${configStore.channels[configStore.i]?.id}`, {
+        await authFetch<any>(`/api/playlist/${configStore.channels[configStore.i]?.id}`, {
             method: 'POST',
             headers: { ...configStore.contentType, ...authStore.authHeader },
             body: JSON.stringify({
@@ -384,13 +377,6 @@ async function savePlaylist(save: boolean) {
                 program: saveList,
             }),
         })
-            .then(async (response) => {
-                if (!response.ok) {
-                    throw new Error(await response.text())
-                }
-
-                return response.json()
-            })
             .then((response: any) => {
                 indexStore.msgAlert('success', response, 2)
             })
@@ -408,7 +394,7 @@ async function deletePlaylist(del: boolean) {
     showDeleteModal.value = false
 
     if (del) {
-        await fetch(`/api/playlist/${configStore.channels[configStore.i]?.id}/${listDate.value}`, {
+        await authFetch(`/api/playlist/${configStore.channels[configStore.i]?.id}/${listDate.value}`, {
             method: 'DELETE',
             headers: { ...configStore.contentType, ...authStore.authHeader },
         }).then(() => {


### PR DESCRIPTION
- add Nuxt-style authFetch with parsed responses and structured errors
- retain authFetchRaw for downloads and upload response handling
- refresh and retry expired access tokens consistently
- synchronize token updates and logout across browser tabs
- simplify authenticated API consumers