### PR TITLE
build: make static VAAPI support optional

### DIFF
--- a/backend/app/build.rs
+++ b/backend/app/build.rs
@@ -71,7 +71,8 @@ fn main() {
         run_npm(&["run", "build"]);
     }
 
-    if std::env::var_os("FFPLAYOUT_VAAPI_SHARED").is_some() {
+    println!("cargo:rerun-if-env-changed=FFPLAYOUT_VAAPI_SHARED");
+    if matches!(std::env::var("FFPLAYOUT_VAAPI_SHARED").as_deref(), Ok("1")) {
         println!("cargo:rustc-link-lib=dylib=va-drm");
         println!("cargo:rustc-link-lib=dylib=va");
         println!("cargo:rustc-link-lib=dylib=drm");

--- a/backend/app/src/api/routes/setup.rs
+++ b/backend/app/src/api/routes/setup.rs
@@ -70,6 +70,7 @@ const APPLICATION_SYSTEM_PATHS: &[&str] = &[
     "/usr/share/ffplayout",
     "/var/lib/ffplayout",
     "/var/log/ffplayout",
+    "/var/www",
 ];
 
 fn validate_setup_paths(settings: &SetupSettings) -> Result<(), ServiceError> {
@@ -274,6 +275,7 @@ mod tests {
     #[test]
     fn setup_paths_allow_application_directories_and_custom_data_roots() {
         assert!(validate_setup_paths(&settings("/mnt/media")).is_ok());
+        assert!(validate_setup_paths(&settings("/var/www/media")).is_ok());
     }
 
     #[test]

--- a/backend/app/src/main.rs
+++ b/backend/app/src/main.rs
@@ -246,7 +246,7 @@ async fn async_main() -> Result<(), ProcessError> {
                 .await?;
             }
         }
-    } else {
+    } else if !ARGS.user_set {
         error!(
             target: Target::Console.as_str(),
             "Run ffplayout with correct parameters! For example:\n    -l 127.0.0.1:8787\n    --channel 1 2 --foreground\n    --channel 1 --generate 2025-01-20 - 2025-01-25\nRun ffplayout -h for more information."

--- a/docker/ffmpeg.Dockerfile
+++ b/docker/ffmpeg.Dockerfile
@@ -14,6 +14,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     CC=gcc \
     CXX=g++
 
+ARG FFMPEG_VAAPI=0
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         autoconf \
@@ -30,9 +32,10 @@ RUN apt-get update && \
         nasm \
         ninja-build \
         perl \
-        pkg-config \
-        libva-dev \
-        libdrm-dev && \
+        pkg-config && \
+    if [ "$FFMPEG_VAAPI" = 1 ]; then \
+        apt-get install -y --no-install-recommends libva-dev libdrm-dev; \
+    fi && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp
@@ -142,8 +145,10 @@ RUN mkdir -p /ffmpeg-debug && \
     git clone --depth 1 --branch "$FFMPEG_VERSION" https://github.com/FFmpeg/FFmpeg.git && cd FFmpeg && \
     avdevice_flag=--disable-avdevice && \
     avfilter_flag=--disable-avfilter && \
+    vaapi_flags= && \
     if [ "$FFMPEG_AVDEVICE" = 1 ]; then avdevice_flag=--enable-avdevice; fi && \
     if [ "$FFMPEG_AVFILTER" = 1 ]; then avfilter_flag=--enable-avfilter; fi && \
+    if [ "$FFMPEG_VAAPI" = 1 ]; then vaapi_flags="--enable-vaapi --enable-libdrm"; fi && \
     if ! ./configure \
         --pkg-config-flags=--static \
         --extra-libs="-lm -lpthread" \
@@ -171,8 +176,7 @@ RUN mkdir -p /ffmpeg-debug && \
         --enable-libx265 \
         --enable-openssl \
         --enable-libvpl \
-        --enable-vaapi \
-        --enable-libdrm \
+        $vaapi_flags \
         --enable-libsvtav1 \
         --enable-libdav1d; then \
         status=1; \

--- a/docker/static.Dockerfile
+++ b/docker/static.Dockerfile
@@ -1,9 +1,10 @@
 FROM localhost/ffplayout-ffmpeg-static:latest
 
 ARG CARGO_FEATURES=embed_frontend
+ARG FFMPEG_VAAPI=0
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    FFPLAYOUT_VAAPI_SHARED=1 \
+    FFPLAYOUT_VAAPI_SHARED=$FFMPEG_VAAPI \
     PKG_CONFIG=/usr/bin/pkg-config \
     PKG_CONFIG_ALL_STATIC=1 \
     PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig \
@@ -40,4 +41,4 @@ RUN apt-get update && \
     cargo install cargo-deb && \
     rm -rf /var/lib/apt/lists/*
 
-CMD ["sh", "-c", "set -eux && echo 'Install frontend dependencies' && npm ci && echo 'Build frontend' && npm run build-only && echo 'Refresh FFmpeg link metadata' && cargo clean -p ffmpeg-sys-next && echo 'Build ffplayout binary' && cargo build --release --package ffplayout --no-default-features --features \"$CARGO_FEATURES\" && version=\"$(sed -n 's/^version = \"\\(.*\\)\"/\\1/p' Cargo.toml | head -1)\" && echo 'Copy build artifacts' && mkdir -p /artifacts && cp target/release/ffplayout /artifacts/ffplayout && echo 'Build deb package' && cargo deb --no-build -p ffplayout --manifest-path backend/app/Cargo.toml -o \"/artifacts/ffplayout_${version}-1_amd64.deb\" && echo 'Artifacts written to /artifacts'"]
+CMD ["sh", "-c", "set -eux && echo 'Install frontend dependencies' && npm ci && echo 'Build frontend' && npm run build-only && echo 'Refresh FFmpeg link metadata' && cargo clean -p ffmpeg-sys-next --release && echo 'Build ffplayout binary' && cargo build --release --package ffplayout --no-default-features --features \"$CARGO_FEATURES\" && version=\"$(sed -n 's/^version = \"\\(.*\\)\"/\\1/p' Cargo.toml | head -1)\" && echo 'Copy build artifacts' && mkdir -p /artifacts && cp target/release/ffplayout /artifacts/ffplayout && echo 'Build deb package' && cargo deb --no-build -p ffplayout --manifest-path backend/app/Cargo.toml -o \"/artifacts/ffplayout_${version}-1_amd64.deb\" && echo 'Artifacts written to /artifacts'"]

--- a/frontend/src/components/config/ConfigUser.vue
+++ b/frontend/src/components/config/ConfigUser.vue
@@ -43,15 +43,13 @@ onMounted(() => {
 })
 
 async function getUsers() {
-    authFetch<User[]>('/api/users', {
+    const data = await authFetch<User[]>('/api/users', {
         method: 'GET',
         headers: authStore.authHeader,
     })
-        .then((data) => {
-            users.value = data
 
-            selected.value = configStore.currentUser
-        })
+    users.value = data
+    selected.value = configStore.currentUser
 }
 
 function onChange(event: Event) {
@@ -116,12 +114,17 @@ async function addUser(add: boolean) {
         if (user.value.username && user.value.password && user.value.password === user.value.confirm) {
             await authStore.inspectToken()
             try {
+                const username = user.value.username
                 await configStore.addNewUser(user.value)
                 showUserModal.value = false
 
                 indexStore.msgAlert('success', t('user.addSuccess'), 2)
                 await getUsers()
-                await getUserConfig()
+                const createdUser = users.value.find((item) => item.username === username)
+                if (createdUser) {
+                    selected.value = createdUser.id
+                    await getUserConfig()
+                }
             } catch {
                 indexStore.msgAlert('error', t('user.addFailed'), 3)
             }
@@ -233,7 +236,7 @@ async function onSubmitUser() {
     </div>
 
     <GenericModal :show="showUserModal" title="Add user" :modal-action="addUser">
-        <div class="w-full max-w-125 h-90">
+        <div class="w-full max-w-125 h-110">
             <fieldset class="fieldset">
                 <legend class="fieldset-legend">{{ t('user.name') }}</legend>
                 <input v-model="user.username" type="text" name="username" class="input w-full" />

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -102,13 +102,15 @@ elif [[ $target == "debian-static" ]]; then
 
     docker build \
         --build-arg FFMPEG_DEBUG="${FFMPEG_DEBUG:-0}" \
-        --build-arg FFMPEG_VERSION="${FFMPEG_VERSION:-release/8.1}" \
+        --build-arg FFMPEG_VERSION="${FFMPEG_VERSION:-release/9.0}" \
+        --build-arg FFMPEG_VAAPI="${FFMPEG_VAAPI:-0}" \
         "${ffmpeg_component_args[@]}" \
         -t localhost/ffplayout-ffmpeg-static:latest \
         -f ./docker/ffmpeg.Dockerfile .
 
     docker build \
         --build-arg CARGO_FEATURES="$static_cargo_features" \
+        --build-arg FFMPEG_VAAPI="${FFMPEG_VAAPI:-0}" \
         -t localhost/ffplayout-static-builder:latest \
         -f ./docker/static.Dockerfile .
 


### PR DESCRIPTION
- install and enable VAAPI dependencies only when requested
- forward FFMPEG_VAAPI through both static build stages
- refresh release FFmpeg metadata before linking
- update the static FFmpeg default to release/9.0
- allow setup paths below /var/www